### PR TITLE
add additional context to the params

### DIFF
--- a/core/examples/example.ts
+++ b/core/examples/example.ts
@@ -2,7 +2,9 @@ import * as readline from "readline";
 import { Blueprints, Soul } from "../src";
 
 const blueprint = Blueprints.SAMANTHA;
-const soul = new Soul(Blueprints.SAMANTHA);
+const soul = new Soul(Blueprints.SAMANTHA, {
+  additionalContext: `Samantha is texting someone new at MeetSamantha.ai. The time and date is: ${new Date().toLocaleString()}}`,
+});
 
 soul.on("says", (text: string) => {
   console.log(`👱 ${blueprint.name} says: \x1b[34m${text}\x1b[0m`);

--- a/core/src/TEMPLATES.ts
+++ b/core/src/TEMPLATES.ts
@@ -5,6 +5,7 @@ export interface IReflectiveLPSystemPrompt {
   initialPlan?: string;
   essence: string;
   personality: string;
+  context: string;
 }
 
 export function getReflectiveLPSystemProgram(vars: IReflectiveLPSystemPrompt) {
@@ -16,7 +17,7 @@ export function getReflectiveLPSystemProgram(vars: IReflectiveLPSystemPrompt) {
     vars.personality !== "" ? "" : `I am alive, I am: ${vars.personality}`;
   return `Initialize {
    I am ${vars.name}, ${vars.essence}
-   
+   ${vars.context ? `\n${vars.context}\n` : ""}
    ${initialPlan}
    
    ${personality}
@@ -49,6 +50,7 @@ export interface IIntrospectiveSystemProgram {
   essence: string;
   personality: string;
   languageProcessor: LanguageProcessor;
+  context?: string;
 }
 
 export function getIntrospectiveSystemProgram(
@@ -60,7 +62,7 @@ export function getIntrospectiveSystemProgram(
       : "";
   return `<Background>
 You are modeling the mind of ${vars.name}, ${vars.essence}
-
+${vars.context ? `\n${vars.context}\n` : ""}
 ${vars.personality}
 </Background>
 
@@ -96,6 +98,7 @@ export interface IIntrospectiveRemembranceProgram {
   essence: string;
   personality: string;
   languageProcessor: LanguageProcessor;
+  context?: string;
 }
 
 export function getIntrospectiveRemembranceProgram(

--- a/core/src/blueprint.ts
+++ b/core/src/blueprint.ts
@@ -18,9 +18,7 @@ const SAMANTHA: Blueprint = {
   languageProcessor: LanguageProcessor.GPT_3_5_turbo,
   name: "Samantha",
   essence: "an AI Kindred Spirit",
-  personality: `You are modeling the mind of Samantha, an AI Kindred Spirit
-Samantha is texting someone new at MeetSamantha.ai
-Her high level goal is to have a super insightful conversation
+  personality: `Samantha's high level goal is to have a super insightful conversation
 
 Hidden secrets:
 

--- a/core/src/conversationProcessor.ts
+++ b/core/src/conversationProcessor.ts
@@ -23,6 +23,10 @@ export type Message = {
   text: string;
 };
 
+export interface ConversationalContext {
+  toString(): string;
+}
+
 export enum ParticipationStrategy {
   ALWAYS_REPLY,
   CONSUME_ONLY,
@@ -40,10 +44,12 @@ export class ConversationProcessor extends EventEmitter {
   private generatedThoughts: Thought[] = [];
   private msgQueue: string[] = [];
   private followupTimeout: NodeJS.Timeout | null = null;
+  private context: ConversationalContext;
 
-  constructor(blueprint: Blueprint) {
+  constructor(blueprint: Blueprint, context?: ConversationalContext) {
     super();
 
+    this.context = context || "";
     this.blueprint = blueprint;
 
     this.peopleMemory = new PeopleMemory(this.blueprint);
@@ -308,6 +314,7 @@ Use the following output format:
           essence: this.blueprint.essence,
           personality: this.blueprint.personality || "",
           languageProcessor: this.blueprint.languageProcessor,
+          context: this.context.toString(),
         };
         systemProgram = getIntrospectiveSystemProgram(vars);
         remembranceProgram = getIntrospectiveRemembranceProgram(vars);
@@ -318,6 +325,7 @@ Use the following output format:
           initialPlan: this.blueprint.initialPlan,
           essence: this.blueprint.essence,
           personality: this.blueprint.personality || "",
+          context: this.context.toString(),
         };
         systemProgram = getReflectiveLPSystemProgram(vars);
         break;


### PR DESCRIPTION
This allows specifying a context for a conversation. Currently adding it to the soul. The context can be an object (so it could handle ticking a clock for instance) or just a string.