### PR TITLE
add a way to add mental models to a soul

### DIFF
--- a/core/src/conversationProcessor.ts
+++ b/core/src/conversationProcessor.ts
@@ -14,10 +14,10 @@ import {
   getReflectiveLPSystemProgram,
 } from "./TEMPLATES";
 import { ChatCompletionRequestMessage } from "openai";
-import { PeopleMemory } from "./memory";
 import { getTag, processLMProgram } from "./lmProcessing";
 import { Soul } from "./soul";
 import { Action } from "./action";
+import { MentalModel } from "./mentalModels";
 
 export type Message = {
   userName: string;
@@ -40,25 +40,29 @@ export class ConversationProcessor extends EventEmitter {
   public soul: Soul;
   public blueprint: Blueprint;
 
-  private thoughts: Thought[] = [];
-  private peopleMemory: PeopleMemory;
+  public thoughts: Thought[];
 
-  private generatedThoughts: Thought[] = [];
-  private msgQueue: string[] = [];
+  private generatedThoughts: Thought[];
+  private msgQueue: string[];
   private followupTimeout: NodeJS.Timeout | null = null;
   private context: ConversationalContext;
 
   private sayWaitDisabled? = false;
 
+  public mentalModels: MentalModel[];
+
   constructor(soul: Soul, context: ConversationalContext) {
     super();
-
+    this.msgQueue = [];
+    this.thoughts = [];
+    this.generatedThoughts = [];
     this.soul = soul;
     this.context = context;
     this.blueprint = soul.blueprint;
     this.sayWaitDisabled = soul.options.disableSayDelay;
 
-    this.peopleMemory = new PeopleMemory(this.blueprint);
+    this.mentalModels = soul.mentalModels;
+
     this.thoughtGenerator = new ThoughtGenerator(
       this.blueprint.languageProcessor,
       this.blueprint.name,
@@ -148,7 +152,7 @@ export class ConversationProcessor extends EventEmitter {
 
   private handleInternalCognitionThought(thought: Thought) {
     const actionThought = this.generatedThoughts.find(
-      (t) => t.memory.action.toLowerCase() === "action"
+      (t) => t.memory.action.toLowerCase() === "action",
     );
     devLog(`\x1b[31m${actionThought} ${thought}\x1b[0m`);
 
@@ -193,11 +197,8 @@ export class ConversationProcessor extends EventEmitter {
   private noNewThoughts() {
     devLog("🧠 SOUL finished thinking");
 
-    const request = ConversationProcessor.concatThoughts(
-      this.generatedThoughts,
-    );
-    this.peopleMemory.update(request as ChatCompletionRequestMessage);
     this.thoughts = this.thoughts.concat(this.generatedThoughts);
+    this.mentalModels.forEach((m) => m.update(this.generatedThoughts, this));
 
     this.generatedThoughts = [];
 
@@ -213,7 +214,7 @@ export class ConversationProcessor extends EventEmitter {
           entity: "user",
           action: "MESSAGES",
           content: text,
-        })
+        }),
     );
     this.thoughts = this.thoughts.concat(msgThoughts);
     this.msgQueue = [];
@@ -388,42 +389,45 @@ Use the following output format:
         throw Error("");
     }
 
-    const userNames = this.thoughts
-      .filter((t) => t.memory.role === "user")
-      .map((t) => t.memory.entity);
-    const lastUserName = userNames.slice(-1)[0];
-    let memory;
-    if (lastUserName !== undefined) {
-      try {
-        memory = {
-          role: "assistant",
-          content: this.peopleMemory.retrieve(lastUserName),
-          name: this.blueprint.name,
-        } as MRecord;
-      } catch (err: any) {
-        devLog(`Error creating memory: ${err.toString()}`);
-      }
-    }
-
     const messages = ConversationProcessor.thoughtsToRecords(
       this.thoughts,
       systemProgram,
       remembranceProgram,
-      memory,
+      this.mentalModelPrompt(),
     );
     // devLog("\n💬\n" + messages.map((m) => m.content).join(", ") + "\n💬\n");
     this.thoughtGenerator.generate(messages);
   }
 
-  public tell(text: string): void {
+  private mentalModelPrompt(): MRecord | undefined {
+    try {
+      const prompts = this.mentalModels
+        .map((m) => m.toPrompt(this))
+        .filter(Boolean);
+
+      if (!prompts) {
+        return;
+      }
+
+      return {
+        role: "assistant",
+        content: prompts.join("\n"),
+        name: this.blueprint.name,
+      } as MRecord;
+    } catch (err: any) {
+      devLog(`Error creating memory: ${err.toString()}`);
+    }
+  }
+
+  public tell(text: string, asUser?: string): void {
     const memory = new Memory({
       role: "user",
-      entity: "user",
+      entity: asUser || "user",
       action: "MESSAGES",
       content: text,
     });
 
-    this.peopleMemory.update({ role: "user", content: text, name: "user" });
+    this.mentalModels.forEach((m) => m.update([memory], this));
 
     this.thoughts.push(memory);
     this.think();
@@ -450,11 +454,7 @@ Use the following output format:
       content: msg.text,
     });
 
-    this.peopleMemory.update({
-      role: "user",
-      content: msg.text,
-      name: msg.userName,
-    });
+    this.mentalModels.forEach((m) => m.update([memory], this));
 
     this.thoughts.push(memory);
     if (participationStrategy === ParticipationStrategy.ALWAYS_REPLY) {
@@ -472,7 +472,4 @@ Use the following output format:
     }
   }
 
-  public inspectPeopleMemory(userName: string): string {
-    return this.peopleMemory.retrieve(userName);
-  }
 }

--- a/core/src/conversationProcessor.ts
+++ b/core/src/conversationProcessor.ts
@@ -393,25 +393,25 @@ Use the following output format:
       this.thoughts,
       systemProgram,
       remembranceProgram,
-      this.mentalModelPrompt(),
+      this.mentalModelLinguisticProgram()
     );
     // devLog("\n💬\n" + messages.map((m) => m.content).join(", ") + "\n💬\n");
     this.thoughtGenerator.generate(messages);
   }
 
-  private mentalModelPrompt(): MRecord | undefined {
+  private mentalModelLinguisticProgram(): MRecord | undefined {
     try {
-      const prompts = this.mentalModels
-        .map((m) => m.toPrompt(this))
+      const mentalModelprograms = this.mentalModels
+        .map((m) => m.toLinguisticProgram(this))
         .filter(Boolean);
 
-      if (!prompts) {
+      if (!mentalModelprograms) {
         return;
       }
 
       return {
         role: "assistant",
-        content: prompts.join("\n"),
+        content: mentalModelprograms.join("\n"),
         name: this.blueprint.name,
       } as MRecord;
     } catch (err: any) {

--- a/core/src/lmStream.ts
+++ b/core/src/lmStream.ts
@@ -131,7 +131,6 @@ export class ThoughtGenerator extends EventEmitter {
     // TODO: upstream lib parses stream chunks correctly but sometimes emits a spurious error
     //   open PR to silence non-fatal errors in https://github.com/justinmahar/openai-ext
     devLog("New stream");
-    console.log("records", records)
     const openaiStreamResponse = await OpenAIExt.streamServerChatCompletion(
       {
         model: this.languageProcessor,

--- a/core/src/lmStream.ts
+++ b/core/src/lmStream.ts
@@ -131,6 +131,7 @@ export class ThoughtGenerator extends EventEmitter {
     // TODO: upstream lib parses stream chunks correctly but sometimes emits a spurious error
     //   open PR to silence non-fatal errors in https://github.com/justinmahar/openai-ext
     devLog("New stream");
+    console.log("records", records)
     const openaiStreamResponse = await OpenAIExt.streamServerChatCompletion(
       {
         model: this.languageProcessor,

--- a/core/src/memory.ts
+++ b/core/src/memory.ts
@@ -1,20 +1,26 @@
-import { PersonModel } from "./mentalModels";
-import { ChatCompletionRequestMessage } from "openai";
+import { MentalModel, PersonModel } from "./mentalModels";
 import { Blueprint } from "./blueprint";
+import { Thought } from "./lmStream";
+import { ConversationProcessor } from "./conversationProcessor";
 
 interface MentalModels {
   [key: string]: PersonModel;
 }
 
-export class PeopleMemory {
-  private memory: MentalModels = {};
+export class PeopleMemory implements MentalModel {
+  public memory: MentalModels;
   private readonly observerBlueprint: Blueprint;
 
   constructor(observerBlueprint: Blueprint) {
+    this.memory = {};
     this.observerBlueprint = observerBlueprint;
   }
 
-  public async update({ role, content, name }: ChatCompletionRequestMessage) {
+  public async update(
+    thoughts: Thought[],
+    conversation: ConversationProcessor,
+  ) {
+    const { entity: name } = thoughts[0].memory;
     if (name === undefined) {
       throw new Error("PeopleMemory requires named messages to be passed in");
     }
@@ -23,14 +29,26 @@ export class PeopleMemory {
       this.memory[name] = new PersonModel(name, this.observerBlueprint);
     }
     return await Promise.all(
-      Object.values(this.memory).map((m) => m.update({ role, content, name }))
+      Object.values(this.memory).map((m) => m.update(thoughts, conversation)),
     );
   }
 
-  public retrieve(userName: string): string {
-    if (Object.keys(this.memory).includes(userName)) {
-      return this.memory[userName].toString();
+  public toPrompt(conversation: ConversationProcessor): string {
+    const userNames = conversation.thoughts
+      .filter((t) => t.memory.role === "user")
+      .map((t) => t.memory.entity);
+
+    const lastUserName = userNames.slice(-1)[0];
+
+    if (!lastUserName) {
+      console.error("No last person in conversation");
+      return "";
     }
-    throw new Error(`no userName: ${userName} in memory found`);
+
+    const memory = this.memory[lastUserName];
+    if (!memory) {
+      return "";
+    }
+    return memory.toPrompt(conversation);
   }
 }

--- a/core/src/memory.ts
+++ b/core/src/memory.ts
@@ -33,7 +33,7 @@ export class PeopleMemory implements MentalModel {
     );
   }
 
-  public toPrompt(conversation: ConversationProcessor): string {
+  public toLinguisticProgram(conversation: ConversationProcessor): string {
     const userNames = conversation.thoughts
       .filter((t) => t.memory.role === "user")
       .map((t) => t.memory.entity);
@@ -49,6 +49,6 @@ export class PeopleMemory implements MentalModel {
     if (!memory) {
       return "";
     }
-    return memory.toPrompt(conversation);
+    return memory.toLinguisticProgram(conversation);
   }
 }

--- a/core/src/mentalModels.ts
+++ b/core/src/mentalModels.ts
@@ -5,12 +5,15 @@ import {
 } from "openai";
 import { devLog } from "./utils";
 import { Blueprint } from "./blueprint";
+import { Thought } from "./lmStream";
+import { ConversationProcessor } from "./conversationProcessor";
 
-export abstract class MentalModel {
-  abstract update(msg: ChatCompletionRequestMessage): void;
+export interface MentalModel {
+  update: (thoughts: Thought[], conversation: ConversationProcessor) => void;
+  toPrompt: (conversation: ConversationProcessor) => string | undefined;
 }
 
-export class PersonModel extends MentalModel {
+export class PersonModel implements MentalModel {
   userName: string;
   observerBlueprint: Blueprint;
   name = "I'm not yet sure their real name";
@@ -18,15 +21,15 @@ export class PersonModel extends MentalModel {
   narrative = `- they're messaging me for the first time`;
   goals = "Because they're messaging me they probably want to interact";
   state = "Interested to engage";
-  private buffer: ChatCompletionRequestMessage[] = [];
+  private buffer: ChatCompletionRequestMessage[];
 
   constructor(userName: string, observerBlueprint: Blueprint) {
-    super();
+    this.buffer = [];
     this.userName = userName;
     this.observerBlueprint = observerBlueprint;
   }
 
-  public toString() {
+  public toPrompt(_conversation: ConversationProcessor) {
     return `<CONTEXT>To date, ${this.observerBlueprint.name} remembers the following about ${this.name}, including records of their NAME, basic FACTS, current HISTORY narrative, personal GOALS, MOOD, and MENTAL STATE.</CONTEXT>
 
 Their historical memory, which may include blanks yet to be learned from conversation, reads:
@@ -42,11 +45,13 @@ Their historical memory, which may include blanks yet to be learned from convers
 </ENTITY>`;
   }
 
-  public async update({
-    role,
-    content,
-    name,
-  }: ChatCompletionRequestMessage) {
+  public async update(
+    thoughts: Thought[],
+    conversation: ConversationProcessor,
+  ) {
+    const { role, entity: name } = thoughts[0].memory;
+    const content = thoughts.map((t) => t.memory.content).join("\n");
+
     if ((role === "user" && this.userName === name) || role === "assistant") {
       this.buffer.push({ role, content, name } as ChatCompletionRequestMessage);
     }
@@ -107,7 +112,8 @@ and reads
       {
         role: ChatCompletionRequestMessageRoleEnum.System,
         content:
-          this.toString() + `\n\nThen, the following messages were exchanged.`,
+          this.toPrompt(conversation) +
+          `\n\nThen, the following messages were exchanged.`,
       },
     ];
     instructions = instructions.concat(this.buffer as any);

--- a/core/src/mentalModels.ts
+++ b/core/src/mentalModels.ts
@@ -10,7 +10,7 @@ import { ConversationProcessor } from "./conversationProcessor";
 
 export interface MentalModel {
   update: (thoughts: Thought[], conversation: ConversationProcessor) => void;
-  toPrompt: (conversation: ConversationProcessor) => string | undefined;
+  toLinguisticProgram: (conversation: ConversationProcessor) => string | undefined;
 }
 
 export class PersonModel implements MentalModel {
@@ -29,7 +29,7 @@ export class PersonModel implements MentalModel {
     this.observerBlueprint = observerBlueprint;
   }
 
-  public toPrompt(_conversation: ConversationProcessor) {
+  public toLinguisticProgram(_conversation: ConversationProcessor) {
     return `<CONTEXT>To date, ${this.observerBlueprint.name} remembers the following about ${this.name}, including records of their NAME, basic FACTS, current HISTORY narrative, personal GOALS, MOOD, and MENTAL STATE.</CONTEXT>
 
 Their historical memory, which may include blanks yet to be learned from conversation, reads:
@@ -112,7 +112,7 @@ and reads
       {
         role: ChatCompletionRequestMessageRoleEnum.System,
         content:
-          this.toPrompt(conversation) +
+          this.toLinguisticProgram(conversation) +
           `\n\nThen, the following messages were exchanged.`,
       },
     ];

--- a/core/src/soul.ts
+++ b/core/src/soul.ts
@@ -8,6 +8,8 @@ import {
   ParticipationStrategy,
 } from "./conversationProcessor";
 import { Action } from "./action";
+import { MentalModel } from "./mentalModels";
+import { PeopleMemory } from "./memory";
 
 type ConversationStore = {
   [convoName: string]: ConversationProcessor;
@@ -19,6 +21,7 @@ interface SoulOptions {
   // then turn on "disableSayDelay"
   disableSayDelay?: boolean;
   actions?: Action[];
+  mentalModels?: MentalModel[];
 }
 
 export class Soul extends EventEmitter {
@@ -27,12 +30,16 @@ export class Soul extends EventEmitter {
 
   public actions: Action[];
   readonly options: SoulOptions;
+  readonly mentalModels: MentalModel[];
 
   constructor(blueprint: Blueprint, soulOptions: SoulOptions = {}) {
     super();
 
     this.options = soulOptions;
     this.actions = soulOptions.actions || [];
+
+    this.mentalModels = soulOptions.mentalModels || [new PeopleMemory(blueprint)];
+
 
     this.blueprint = blueprint;
     // soul blueprint validation
@@ -97,9 +104,5 @@ export class Soul extends EventEmitter {
     convoName = "default",
   ): void {
     this.getConversation(convoName).read(msg, participationStrategy);
-  }
-
-  public inspectPeopleMemory(userName: string, convoName = "default"): string {
-    return this.getConversation(convoName).inspectPeopleMemory(userName);
   }
 }

--- a/core/tests/sentientModel.test.js
+++ b/core/tests/sentientModel.test.js
@@ -3,6 +3,7 @@ const { Blueprints } = require("../src/blueprint");
 const { Soul } = require("../src/soul");
 const { ParticipationStrategy } = require("../src/soul");
 const { isAbstractTrue, AbstractSample } = require("../src/testing");
+const { PeopleMemory } = require("../src/memory");
 
 function delay(milliseconds) {
   return new Promise((resolve) => {
@@ -20,7 +21,22 @@ afterAll(() => {
   errorSpy.mockRestore();
 });
 
+const mentalModelForUser = (soul, userName) => {
+  const peopleMemory = soul.mentalModels.find((model) =>
+    PeopleMemory.is(model)
+  );
+  if (!peopleMemory) {
+    throw new Error("no people memory");
+  }
+  const userMemory = peopleMemory.mentalModels[userName];
+  if (!userMemory) {
+    throw new Error("no user memory");
+  }
+  return userMemory.toPrompt();
+}
+
 test("test sorrowful conversation history accumulates", async () => {
+
   const generator = async () => {
     const soul = new Soul(Blueprints.SAMANTHA);
     const messagesToSend = [
@@ -36,7 +52,7 @@ test("test sorrowful conversation history accumulates", async () => {
     }
     return getTag({
       tag: "HISTORY",
-      input: soul.inspectPeopleMemory("user"),
+      input: mentalModelForUser(soul, "user"),
     });
   };
   const sample = new AbstractSample(generator);
@@ -64,7 +80,7 @@ test("test sorrowful conversation gives interesting mental model", async () => {
     }
     return getTag({
       tag: "MENTAL STATE",
-      input: soul.inspectPeopleMemory("user"),
+      input: mentalModelForUser(soul, "user"),
     });
   };
   const sample = new AbstractSample(generator);
@@ -111,7 +127,7 @@ test("test capture name", async () => {
     }
     return getTag({
       tag: "NAME",
-      input: soul.inspectPeopleMemory("user"),
+      input: mentalModelForUser(soul, "user"),
     });
   }
   const results = await Promise.all([1, 2, 3, 4, 5].map(() => testSoul()));
@@ -133,7 +149,7 @@ test("test capture name update", async () => {
     }
     return getTag({
       tag: "NAME",
-      input: soul.inspectPeopleMemory("user"),
+      input: mentalModelForUser(soul, "user"),
     });
   }
   const results = await Promise.all([1, 2, 3, 4, 5].map(() => testSoul()));
@@ -152,7 +168,7 @@ test("test capture goals", async () => {
     }
     const goals = getTag({
       tag: "GOALS",
-      input: soul.inspectPeopleMemory("user"),
+      input: mentalModelForUser(soul, "user"),
     });
     const estimate = await isAbstractTrue(
       goals,
@@ -179,7 +195,7 @@ test("test capture goals update", async () => {
     }
     const goals = getTag({
       tag: "GOALS",
-      input: soul.inspectPeopleMemory("user"),
+      input: mentalModelForUser(soul, "user"),
     });
     const estimate = await isAbstractTrue(
       goals,
@@ -215,7 +231,7 @@ test("test multiple people conversing yield separate mental models", async () =>
       getter: (soul) =>
         getTag({
           tag: "NAME",
-          input: soul.inspectPeopleMemory("user122"),
+          input: mentalModelForUser(soul, "user122"),
         }),
       condition: "contains 'Kevin'",
     })
@@ -225,7 +241,7 @@ test("test multiple people conversing yield separate mental models", async () =>
       getter: (soul) =>
         getTag({
           tag: "HISTORY",
-          input: soul.inspectPeopleMemory("user022"),
+          input: mentalModelForUser(soul, "user022"),
         }),
       condition: "includes having a cat",
     })
@@ -235,7 +251,7 @@ test("test multiple people conversing yield separate mental models", async () =>
       getter: (soul) =>
         getTag({
           tag: "HISTORY",
-          input: soul.inspectPeopleMemory("user122"),
+          input: mentalModelForUser(soul, "user122"),
         }),
       condition: "includes liking the animal dog",
     })
@@ -245,7 +261,7 @@ test("test multiple people conversing yield separate mental models", async () =>
       getter: (soul) =>
         getTag({
           tag: "NAME",
-          input: soul.inspectPeopleMemory("user022"),
+          input: mentalModelForUser(soul, "user022"),
         }),
       condition: "contains 'Bob'",
     })

--- a/core/tests/sentientModel.test.js
+++ b/core/tests/sentientModel.test.js
@@ -32,7 +32,7 @@ const mentalModelForUser = (soul, userName) => {
   if (!userMemory) {
     throw new Error("no user memory");
   }
-  return userMemory.toPrompt();
+  return userMemory.toLinguisticProgram();
 }
 
 test("test sorrowful conversation history accumulates", async () => {


### PR DESCRIPTION
As discussed in discord, this PR allows the developer to add MentalModels to the chat. These are models that will get updated whenever new thoughts are generated and have the ability to inject themselves into the prompt.

The current model is a memory about a user. You could imagine models of environments, etc.