### PR TITLE
add function call return support to the program executor

### DIFF
--- a/core/src/cortexStep.ts
+++ b/core/src/cortexStep.ts
@@ -212,10 +212,13 @@ Reply in the output format: \`${beginning}[[fill in]]</${action}>\`. Double chec
     ] as ChatMessage[];
     const instructions = this.messages.concat(nextInstructions);
     devLog("instructions: " + instructions);
-    const resp = await this.processor.execute(instructions, {
+    const { content: resp } = await this.processor.execute(instructions, {
       stop: `</${action}`,
     });
     devLog("resp:", resp);
+    if (!resp) {
+      throw new Error("missing response");
+    }
     const nextValue = resp.replace(/^[^>]*>{0,1}[^>]*>/g, "");
     devLog("next value: ", nextValue);
     const contextCompletion = [
@@ -257,11 +260,13 @@ Use the output format <UNFILTERED_ANSWER>[[fill in]]</UNFILTERED_ANSWER>
       },
     ] as ChatMessage[];
     const instructions = this.messages.concat(nextInstructions);
-    return (
-      await this.processor.execute(instructions, {
-        stop: "</UNFILTERED_ANSWER",
-      })
-    ).replace("<UNFILTERED_ANSWER>", "");
+    const { content } = await this.processor.execute(instructions, {
+      stop: "</UNFILTERED_ANSWER",
+    });
+    if (!content) {
+      throw new Error("expecting content");
+    }
+    return content.replace("<UNFILTERED_ANSWER>", "");
   }
 
   public updateMemory(

--- a/core/src/languageModels/index.ts
+++ b/core/src/languageModels/index.ts
@@ -21,6 +21,11 @@ interface LanguageModelProgramExecutorExecuteOptions {
   stop?: string;
 }
 
+export interface ExecutorResponse {
+  content?: string | null;
+  functionCall?: FunctionCall;
+}
+
 /**
  * Execute a language model program and get the results as a string (non-streaming)
  */
@@ -28,7 +33,7 @@ export interface LanguageModelProgramExecutor {
   execute(
     records: ChatMessage[],
     requestParams?: LanguageModelProgramExecutorExecuteOptions
-  ): Promise<string>;
+  ): Promise<ExecutorResponse>;
 }
 
 /**

--- a/core/src/languageModels/openAI.ts
+++ b/core/src/languageModels/openAI.ts
@@ -4,6 +4,7 @@ import {
   ChatCompletionStreamer,
   ChatMessage,
   CreateChatCompletionParams,
+  ExecutorResponse,
   LanguageModelProgramExecutor,
 } from ".";
 
@@ -80,12 +81,15 @@ export class OpenAILanguageProgramProcessor
   async execute(
     messages: ChatMessage[],
     requestParams: ChatCompletionParams = {}
-  ): Promise<string> {
+  ): Promise<ExecutorResponse> {
     const res = await this.client.chat.completions.create({
       ...this.defaultParams,
       ...requestParams,
       messages: messages,
     });
-    return res?.choices[0]?.message?.content || "";
+    return {
+      content: res?.choices[0]?.message?.content,
+      functionCall: res?.choices[0]?.message?.function_call,
+    };
   }
 }

--- a/core/src/programs/PeopleMemory/PersonModel.ts
+++ b/core/src/programs/PeopleMemory/PersonModel.ts
@@ -113,7 +113,12 @@ and reads
     instructions = instructions.concat([
       { role: ChatMessageRoleEnum.System, content: program },
     ] as any);
-    const res = await this.soul.languageProgramExecutor.execute(instructions);
+    const { content: res } = await this.soul.languageProgramExecutor.execute(
+      instructions
+    );
+    if (!res) {
+      throw new Error("missing response");
+    }
     devLog(`Mental model updated from "${content}" to \x1b[31m${res}\x1b[0m`);
 
     this.name = getTag({ tag: "NAME", input: res });

--- a/core/src/programs/participationStrategies/GroupParticipationStrategy.ts
+++ b/core/src/programs/participationStrategies/GroupParticipationStrategy.ts
@@ -57,7 +57,12 @@ Use the following output format:
 `.trim(),
       },
     ];
-    const res = await soul.languageProgramExecutor.execute(instructions);
+    const { content: res } = await soul.languageProgramExecutor.execute(
+      instructions
+    );
+    if (!res) {
+      throw new Error("missing response");
+    }
     const answer = getTag({ tag: "ANSWER", input: res }).toLowerCase();
     devLog(res);
     return answer === "yes";

--- a/core/src/testing.ts
+++ b/core/src/testing.ts
@@ -50,7 +50,10 @@ The optimal assessment is given
 <TEST>`,
     },
   ];
-  const res = await executor.execute(instructions);
+  const { content: res } = await executor.execute(instructions);
+  if (!res) {
+    throw new Error("missing response");
+  }
   const confidence = Number(getTag({ tag: "CONFIDENCE", input: res }));
   const reasoning = getTag({ tag: "THINKING", input: res });
   return {


### PR DESCRIPTION
~this builds upon #61 so will become a smaller PR once that's merged.~

* add the ability to add function specification and model return of function calls to the executor output
* use that new return throughout the codebase, erroring now when no content returned.

This is an intermediate step to allowing experimentation with the function call system.

UPDATE: rebased #61