### PR TITLE
fix up build, usage errors in latest next imports

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -18,7 +18,7 @@
         "next": "^13.4.8",
         "openai": "^4.2.0",
         "react": "^18.2.0",
-        "zod": "^3.22.2",
+        "zod": "^3.22.4",
         "zod-to-json-schema": "^3.21.4"
       },
       "devDependencies": {
@@ -7833,9 +7833,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.22.2",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.2.tgz",
-      "integrity": "sha512-wvWkphh5WQsJbVk1tbx1l1Ly4yg+XecD+Mq280uBGt9wa5BKSWf4Mhp6GmrkPixhMxmabYY7RbzlwVP32pbGCg==",
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -13518,9 +13518,9 @@
       "dev": true
     },
     "zod": {
-      "version": "3.22.2",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.2.tgz",
-      "integrity": "sha512-wvWkphh5WQsJbVk1tbx1l1Ly4yg+XecD+Mq280uBGt9wa5BKSWf4Mhp6GmrkPixhMxmabYY7RbzlwVP32pbGCg=="
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg=="
     },
     "zod-to-json-schema": {
       "version": "3.21.4",

--- a/core/package.json
+++ b/core/package.json
@@ -2,10 +2,10 @@
   "name": "socialagi",
   "version": "0.0.32",
   "description": "Subroutines for AI Souls",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "rm -rf dist && tsc",
     "test": "mocha",
     "prepublishOnly": "npm run build",
     "test-example": "ts-node examples/example.ts",
@@ -14,11 +14,11 @@
     "test-example4": "ts-node examples/example4.ts"
   },
   "exports": {
-    ".": "./dist/index.js",
-    "./next": "./dist/next/index.js"
+    ".": "./dist/src/index.js",
+    "./next": "./dist/src/next/index.js"
   },
   "files": [
-    "dist"
+    "dist/src"
   ],
   "keywords": [
     "soul",
@@ -79,7 +79,7 @@
     "next": "^13.4.8",
     "openai": "^4.2.0",
     "react": "^18.2.0",
-    "zod": "^3.22.2",
+    "zod": "^3.22.4",
     "zod-to-json-schema": "^3.21.4"
   }
 }

--- a/core/src/next/README.md
+++ b/core/src/next/README.md
@@ -33,15 +33,11 @@ Cognitive functions are used to generate responses. They are based on OpenAI's f
 
 ```typescript
 
-internalMonologue("feels", "Bogus notes how it feels to themself in one sentence")
-
 enum ConversationalAction {
    none = "none",
    rambles = "rambles",
 }
 decision("decision", ConversationalAction)
-
-externalDialog("shouts", "Bogus shouts incredibly loudly with all caps")
 
 brainstorm("Given the context, what are three lunches Samantha could make with those ingredients?")
 ```
@@ -49,7 +45,8 @@ brainstorm("Given the context, what are three lunches Samantha could make with t
 You can easily build your own cognitive functions and get strongly typed output from the Open Soul like this:
 
 ```typescript
-import { z } from "zod"
+// note that importing z from here is important as if you import it from "zod" then you will get type errors
+import { z } from "socialagi/next"
 
 export const queryMemory = (query:string) => {
   return () => {

--- a/core/src/next/index.ts
+++ b/core/src/next/index.ts
@@ -2,3 +2,6 @@ export * from './CortexStep';
 export * from './languageModels';
 export * from './cognitiveFunctions';
 export * from "./instrumentation";
+// Note, it's important that users use *this* z when creating cognitive functions as 
+// if they do not, then they will get infinite type loops that will crash the compiler
+export { z } from "zod"


### PR DESCRIPTION
This was a doozy, in order to use a cognitive function it needs to be the same zod as what's in the repo, or else you get an infinite type recursion problem at compile time in the project that uses socialagi.

This now exports "z" from the socialagi/next package so that you can make sure you're always on the same zod.

Other than that, I cleaned up the readme a little here, and took this moment to upgrade zod to the latest.