### PR TITLE
quick DX fixes for using the web browser outside this repo

### DIFF
--- a/tools/package.json
+++ b/tools/package.json
@@ -2,12 +2,15 @@
   "name": "@socialagi/tools",
   "version": "0.0.1",
   "description": "A library for loading web pages and other resources for use in socialagi. It provides efficient and reliable tools for Open Souls to use.",
-  "main": "dist/index.js",
+  "main": "dist/src/index.js",
   "scripts": {
     "build": "tsc",
     "test": "mocha",
     "prepublishOnly": "npm run build"
   },
+  "files": [
+    "dist/src"
+  ],
   "repository": {
     "type": "git",
     "url": "git@github.com:opensouls/SocialAGI.git"

--- a/tools/src/browser.ts
+++ b/tools/src/browser.ts
@@ -1,10 +1,15 @@
 import TurndownService from "turndown"
-import { Browser } from "puppeteer";
+import puppeteer, { Browser, PuppeteerLaunchOptions } from "puppeteer";
+export { Browser } from "puppeteer"
 
 export interface WebBrowserArgs {
   browser: Browser;
   url: string;
   waitFor?: string;
+}
+
+export const createBrowser = (opts: PuppeteerLaunchOptions = {headless: "new"}): Promise<Browser> => {
+  return puppeteer.launch(opts)
 }
 
 const metadataFunction = `

--- a/tools/tests/browser.spec.ts
+++ b/tools/tests/browser.spec.ts
@@ -1,12 +1,11 @@
 import { expect } from 'chai'
-import puppeteer, { Browser } from 'puppeteer'
-import { WebLoader } from '../src';
+import { WebLoader, Browser, createBrowser } from '../src';
 
 describe("browser", () => {
   let browser:Browser
 
   before(async () => {
-    browser = await puppeteer.launch({ headless: "new" });
+    browser = await createBrowser()
   })
 
   after(async () => {


### PR DESCRIPTION
* fix build problem in the tool repo
* quick DX fixes to not have to install puppeteer separately in your repo, or know exactly how to configure it. The test file illustrates the usage change.