### PR TITLE
add better retry handling in the repo and documentation

### DIFF
--- a/core/src/next/README.md
+++ b/core/src/next/README.md
@@ -71,6 +71,40 @@ const resp = await step.next(queryMemory("What is the name I'm looking for? Answ
 
 ```
 
+### Other Language Models
+
+CortexSteps can handle other language processors that implement `LanguageModelProgramExecutor` interface. We also include a `FuncionlessLLM` executor within the repo that lets you call any OpenAI API compatible API even if does not support function calls or multiple system messages.
+
+```typescript
+import { FunctionlessLLM } from "socialagi/next";
+
+const queryMemory = (query: string) => {
+  return () => {
+    return {
+      name: "queryMemory",
+      description: query,
+      parameters: z.object({
+        answer: z.string().describe(`The answer to: ${query}`)
+      })
+    };
+  }
+}
+let step = new CortexStep("Jonathan", {
+  processor: new FunctionlessLLM({
+    baseURL: "http://localhost:1234/v1",
+    // optionally, if your API only supports one single system call, you can set this to true
+    // and it will concatenate all system messages into a single message.
+    compressSystemMessages: false
+  })
+});
+step = step.withMemory([{
+  role: ChatMessageRoleEnum.System,
+  content: "The name you are looking for is Jonathan"
+}])
+const resp = await step.next(queryMemory("What is the name I'm looking for? Answer in a single word"))
+
+```
+
 
 ### Instrumentation
 

--- a/core/src/next/README.md
+++ b/core/src/next/README.md
@@ -73,7 +73,7 @@ const resp = await step.next(queryMemory("What is the name I'm looking for? Answ
 
 ### Other Language Models
 
-CortexSteps can handle other language processors that implement `LanguageModelProgramExecutor` interface. We also include a `FuncionlessLLM` executor within the repo that lets you call any OpenAI API compatible API even if does not support function calls or multiple system messages.
+CortexSteps can handle other language processors that implement `LanguageModelProgramExecutor` interface. The package also includes a `FuncionlessLLM` executor that lets you call any OpenAI API compatible API even if does not support function calls or multiple system messages.
 
 ```typescript
 import { FunctionlessLLM } from "socialagi/next";

--- a/core/src/next/README.md
+++ b/core/src/next/README.md
@@ -37,7 +37,7 @@ enum ConversationalAction {
    none = "none",
    rambles = "rambles",
 }
-decision("decision", ConversationalAction)
+decision("Should Bogus ramble or stop talking?", ConversationalAction)
 
 brainstorm("Given the context, what are three lunches Samantha could make with those ingredients?")
 ```

--- a/core/src/next/languageModels/index.ts
+++ b/core/src/next/languageModels/index.ts
@@ -1,6 +1,7 @@
 import { ZodSchema } from "zod";
 
 export { OpenAILanguageProgramProcessor } from "./openAI";
+export { FunctionlessLLM } from "./FunctionlessLLM";
 
 export interface LanguageModelProgramExecutorExecuteOptions {
   stop?: string;


### PR DESCRIPTION
* handles the case where json is prefaced with something like "You should call the function with: "
* better retry logic, that won't repeat the same command messages over and over
* some documentation on how to use the new language processor
* fix the bug @kafischer pointed out of not adding new lines on system message concatenate
* fix package export

I also have now tried this with collective cognition mistral 7b.