### PR TITLE
fix tooling but on really long pages

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "socialagi",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "socialagi",
-      "version": "0.0.32",
+      "version": "0.0.33",
       "license": "ISC",
       "dependencies": {
         "@opentelemetry/api": "^1.6.0",

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socialagi",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "description": "Subroutines for AI Souls",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/tools/src/index.ts
+++ b/tools/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./browser"
 export * from "./sectionSplitter"
+export * from "./tokenCounter"

--- a/tools/src/sectionSplitter.ts
+++ b/tools/src/sectionSplitter.ts
@@ -1,99 +1,142 @@
 import {
-    isWithinTokenLimit,
-} from 'gpt-tokenizer/model/gpt-3.5-turbo'
+  isWithinTokenLimit,
+} from './tokenCounter'
 
 const HEADER_REGEX = /((?<=\n[-]{2,}\n)|(?=\n# |\n## |\n### |\n#### ))/g;
 
 const PUNCTUATION = /[\.\?\!]\s/g
 
 function combineSections(sections: string[], maxTokensPerSection: number): string[] {
-    let combinedSections: string[] = [];
-    let currentSection = "";
+  let combinedSections: string[] = [];
+  let currentSection = "";
 
-    for (let section of sections) {
-        if (isWithinTokenLimit(currentSection + section, maxTokensPerSection)) {
-            currentSection += section;
-        } else {
-            combinedSections.push(currentSection);
-            currentSection = section;
-        }
+  for (let section of sections) {
+    if (isWithinTokenLimit(currentSection + section, maxTokensPerSection)) {
+      currentSection += section;
+    } else {
+      combinedSections.push(currentSection);
+      currentSection = section;
     }
+  }
 
-    if (currentSection) {
-        combinedSections.push(currentSection);
-    }
+  if (currentSection) {
+    combinedSections.push(currentSection);
+  }
 
-    return combinedSections;
+  return combinedSections;
 }
 
+const containsMarkdownHeader = (line: string, nextLine: string) => {
+  return /^#+\s*/.test(line) || /^-{2,}/.test(nextLine) || /^={2,}/.test(nextLine)
+}
+
+const countHeaders = (text: string) => {
+  const lines = text.split('\n');
+  let count = 0
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const nextLine = lines[i + 1];
+
+    // If the line is a header, start a new section
+    if (containsMarkdownHeader(line, nextLine)) {
+      count++
+    }
+  }
+  return count
+}
 
 const splitTextByHeaders = (text: string) => {
-    const lines = text.split('\n');
-    const sections = [];
-    let currentSection = '';
-  
-    for (let i = 0; i < lines.length; i++) {
-      const line = lines[i];
-      const nextLine = lines[i + 1];
-    
-      // If the line is a header, start a new section
-      if (/^#+\s*/.test(line) || /^-{2,}/.test(nextLine) || /^={2,}/.test(nextLine)) {
-        if (currentSection) {
-            sections.push(currentSection);
-        }
-        currentSection = '';
-      }
-      currentSection += line + '\n';
-    }
-  
-    // Add the last section
-    if (currentSection) {
-      sections.push(currentSection);
-    }
-  
-    return sections
-}
+  const lines = text.split('\n');
+  const sections = [];
+  let currentSection = '';
 
-const splitTextByPunctuation = (text: string, maxTokensPerSection: number) => {
-    let smallerSections: string[] = [];
-    const sections = text.split(PUNCTUATION);
-    for (const section of sections) {
-        if (isWithinTokenLimit(section, maxTokensPerSection)) {
-            smallerSections.push(section);
-            continue
-        }
-        // otherwise split on spaces
-        const words = section.split(' ');
-        smallerSections = smallerSections.concat(words)
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const nextLine = lines[i + 1];
+
+    // If the line is a header, start a new section
+    if (containsMarkdownHeader(line, nextLine)) {
+      if (currentSection) {
+        sections.push(currentSection);
+      }
+      currentSection = '';
     }
-    return smallerSections
+    currentSection += line + '\n';
+  }
+
+  // Add the last section
+  if (currentSection) {
+    sections.push(currentSection);
+  }
+
+  return sections
+}
+const splitTextByPunctuation = (text: string, maxTokensPerSection: number) => {
+  let sections: string[] = [];
+  let currentSection = "";
+  const sentences = text.split(PUNCTUATION);
+
+  for (let sentence of sentences) {
+    if (isWithinTokenLimit(currentSection + sentence, maxTokensPerSection)) {
+      currentSection += sentence;
+    } else {
+      if (isWithinTokenLimit(sentence, maxTokensPerSection)) {
+        sections.push(currentSection);
+        currentSection = sentence;
+      } else {
+        // If the sentence is too large, split it into words
+        const words = sentence.split(' ');
+        for (let word of words) {
+          if (isWithinTokenLimit(currentSection + word, maxTokensPerSection)) {
+            currentSection += word;
+          } else {
+            sections.push(currentSection);
+            currentSection = word;
+          }
+        }
+      }
+    }
+  }
+
+  // Add the last section
+  if (currentSection) {
+    sections.push(currentSection);
+  }
+
+  return sections;
 }
 
 export function splitSections(markdown: string, maxTokensPerSection = 2000): string[] {
+  try {
     if (markdown.length === 0) {
-        return [];
+      return [];
     }
     let sections: string[] = [];
 
     // If the markdown is less than maxTokensPerSection then just return the whole thing
     if (isWithinTokenLimit(markdown, maxTokensPerSection)) {
-        return [markdown];
+      return [markdown];
     }
 
     // Split the markdown into sections by headers
     const headerSections = splitTextByHeaders(markdown);
     for (const section of headerSections) {
-        if (isWithinTokenLimit(section, maxTokensPerSection)) {
-            sections.push(section);
-            continue
-        }
-        if (HEADER_REGEX.test(section)) {            
-            sections = sections.concat(splitSections(section, maxTokensPerSection));
-            continue
-        }
-        const punctuationSections = splitTextByPunctuation(section, maxTokensPerSection);
-        sections = sections.concat(punctuationSections);
+      if (isWithinTokenLimit(section, maxTokensPerSection)) {
+        sections.push(section);
+        continue
+      }
+      if (countHeaders(section) >= 2) {
+        sections = sections.concat(splitSections(section, maxTokensPerSection));
+        continue
+      }
+      const punctuationSections = splitTextByPunctuation(section, maxTokensPerSection);
+      sections = sections.concat(punctuationSections);
     }
 
     return combineSections(sections, maxTokensPerSection)
+  } catch (err) {
+    console.error('error splitting sections', err)
+    throw err
+  }
 }

--- a/tools/src/tokenCounter.ts
+++ b/tools/src/tokenCounter.ts
@@ -1,0 +1,18 @@
+import {
+  isWithinTokenLimit as isWithinTokenLimitGPT3,
+} from 'gpt-tokenizer/model/gpt-3.5-turbo'
+
+export const isWithinTokenLimit = (text: string, maxTokens: number) => {
+  // this is a quick sanity check because gpt-tokenizer can get into a kind of crazy loop
+  // on super huge documents.
+  const words = text.split(" ")
+  if (words.length * 5 > maxTokens) {
+    return false;
+  }
+
+  if (words.length < maxTokens) {
+    return true
+  }
+
+  return isWithinTokenLimitGPT3(text, maxTokens);
+}

--- a/tools/tests/browser.spec.ts
+++ b/tools/tests/browser.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai'
-import { WebLoader, Browser, createBrowser } from '../src';
+import { WebLoader, Browser, createBrowser, splitSections } from '../src';
 
 describe("browser", () => {
   let browser:Browser
@@ -20,6 +20,15 @@ describe("browser", () => {
     expect(pageContent).to.contain("I illustrated just how we’re going to imbue AI with the indescribable essence of humanity")
     expect(metadata.title).to.equal("Kevin Fischer on X")
     expect(metadata.source).to.equal(url)
+  })
+
+  it("loads and splits a really long site", async () => {
+    const url = "https://docs.unrealengine.com/5.3/en-US/installing-unreal-engine/"
+    const loader = new WebLoader({ browser, url })
+    const { pageContent, metadata } = await loader.load()
+    const sections = splitSections(pageContent, 500)
+    expect(sections).to.exist
+    expect(sections).to.have.length.greaterThan(50)
   })
 
 })

--- a/tools/tests/sectionSplitter.spec.ts
+++ b/tools/tests/sectionSplitter.spec.ts
@@ -1,46 +1,12 @@
 import { expect } from "chai"
 import { splitSections } from "../src"
-describe("SectionSplitter", () => {
 
+describe("SectionSplitter", () => {
   it("breaks down markdown into sections based on token length, attempting to respect sections", () => {
     const split = splitSections(longPost, 2000)
-    expect(split).to.have.length(2)
+    expect(split).to.have.length(4)
   })
-
 })
-
-const post = `
-[](https://skale.space/blog/introducing-the-levitation-protocol-skales-solution-for-decentralized-zero-knowledge-proofs)
-
-Introducing Levitation Protocol: The Future of ZK Scaling
-
-[](/)
-
-[Home](/)
-
-[
-
-Network
-
-](/network)
-
-[Stats](/stats)[Ecosystem](/ecosystem)[Token](https://skale.space/network/#token)
-
-[
-
-Developers
-
-](/developers)
-
-[Grants](https://skale.space/developers/#grants)[Validators](https://skale.space/developers/#validators)
-
-[Blog](/blog)[Community](/community)[About](/about)
-
-*   [](#)
-*   [](#)
-*   [](#)
-*   [](#)
-`
 
 const longPost = `
 [](https://skale.space/blog/introducing-the-levitation-protocol-skales-solution-for-decentralized-zero-knowledge-proofs)


### PR DESCRIPTION
On very large sites, the splitSections was going into infinite recursion when a section containing a single header was still too large to fit into a single tokenLength window.

This will now also export the isWithinTokenLimit for convenience and also has a couple of early return scenarios to speed up processing of way too high or way too low token counts.