### PR TITLE
features in /next for use in the docs

### DIFF
--- a/core/.mocharc.json
+++ b/core/.mocharc.json
@@ -1,6 +1,7 @@
 {
   "extension": ["ts"],
+  "file": ["tests/shared/dotenv.ts"],
   "spec": ["tests/**/*.spec.ts"],
   "require": ["ts-node/register"],
-  "timeout": 35000
+  "timeout": 60000
 }

--- a/core/src/next/cognitiveFunctions.ts
+++ b/core/src/next/cognitiveFunctions.ts
@@ -1,7 +1,33 @@
 import { EnumLike, z } from "zod"
-import { CortexStep } from "./CortexStep";
+import { CortexStep, NextFunction, StepCommand } from "./CortexStep";
 import { ChatMessageRoleEnum } from "./languageModels";
 import { html } from "common-tags";
+
+
+export const externalDialog = (extraInstructions?: string) => {
+  return instruction(({ entityName: name }: CortexStep) => {
+    return html`
+      ${extraInstructions}
+
+      ${name} should respond as if they were spekaing out loud. The response should be short (as most speech is short), include appropriate verbal ticks, use all caps when SHOUTING, and use punctuation (such as ellipses) to indicate pauses and breaks.
+      Do not include any other text than ${name}'s response!
+      Respond in the first person voice (use "I" instead of "${name}") and speaking style of ${name}. Pretend to be ${name}!
+    `
+  })
+}
+
+export const internalMonologue = (extraInstructions?: string) => {
+  return instruction(({ entityName: name }: CortexStep) => {
+    return html`
+      ${extraInstructions}
+
+      What would ${name} think to themselves? What would their internal monologue be?
+      The response should be short (as most internal thinking is short).
+      Do not include any other text than ${name}'s thoughts.
+      Respond in the first person voice (use "I" instead of "${name}") and speaking style of ${name}. Pretend to be ${name}!
+    `
+  })
+}
 
 export const decision = (description:string, choices: EnumLike) => {
   return () => {
@@ -72,10 +98,22 @@ export const queryMemory = (query:string) => {
   }
 }
 
-export const stringCommand = (command:string) => {
+/**
+ * `instruction` is used for instructions that do not use function calling. 
+ * Instead, these instructions are inserted directly into the dialog. 
+ * However, they are removed when the answer is returned.
+ */
+export const instruction = (command: StepCommand):NextFunction<unknown, string, string> => {
   return () => {
     return {
       command,
     }
   }
+}
+
+/**
+ * @deprecated
+ */
+export const stringCommand = (command:StepCommand) => {
+  return instruction(command)
 }

--- a/core/src/next/cognitiveFunctions.ts
+++ b/core/src/next/cognitiveFunctions.ts
@@ -9,7 +9,7 @@ export const externalDialog = (extraInstructions?: string) => {
     return html`
       ${extraInstructions}
 
-      ${name} should respond as if they were spekaing out loud. The response should be short (as most speech is short), include appropriate verbal ticks, use all caps when SHOUTING, and use punctuation (such as ellipses) to indicate pauses and breaks.
+      ${name} should respond as if they were speaking out loud. The response should be short (as most speech is short), include appropriate verbal ticks, use all caps when SHOUTING, and use punctuation (such as ellipses) to indicate pauses and breaks.
       Do not include any other text than ${name}'s response!
       Respond in the first person voice (use "I" instead of "${name}") and speaking style of ${name}. Pretend to be ${name}!
     `

--- a/core/src/next/cortexScheduler.ts
+++ b/core/src/next/cortexScheduler.ts
@@ -1,0 +1,172 @@
+// one process at a time
+// get local copy of memory to work with
+// memory updates occur inbetween processes
+
+import {
+  AbortController as NodeAbortController,
+  AbortSignal,
+} from "abort-controller";
+import { CortexStep } from "./CortexStep";
+import { ChatMessage } from "./languageModels";
+import { Mutex } from "async-mutex";
+
+const AbortController = globalThis.AbortController || NodeAbortController;
+
+export interface Job {
+  process: MentalProcess;
+  newMemory: ChatMessage;
+  abortController: AbortController;
+  jobCompletion: { resolve: () => void; promise: Promise<void> };
+}
+
+type ManagerOptions = {
+  queuingStrategy: QueuingStrategy;
+};
+
+/**
+ * `MentalProcess` is a type that represents a function performing cognitive
+ * operations. These operations could be anything from data retrieval,
+ * processing, or AI computations. It requires an AbortSignal for handling
+ * abort scenarios, a newMemory object for context, and lastStep which is the
+ * last performed CortexStep. It returns a promise that resolves with a new
+ * CortexStep.
+ *
+ * @typedef {(signal: AbortSignal, newMemory: ChatMessage, lastStep: CortexStep) => Promise<CortexStep>} MentalProcess
+ */
+export type MentalProcess = (
+  signal: AbortSignal,
+  newMemory: ChatMessage,
+  lastStep: CortexStep
+) => Promise<CortexStep>;
+
+/**
+ * `ProcessConfig` interface represents the configuration for a mental process.
+ * It contains the name of the process and the process function itself.
+ *
+ * @interface ProcessConfig
+ */
+export interface ProcessConfig {
+  name: string;
+  process: MentalProcess;
+}
+
+/**
+ * `QueuingStrategy` is a function type that defines how jobs are queued in the
+ * CortexScheduler. It takes the current job, the existing queue, and the new job
+ * and returns a modified queue.
+ *
+ * @typedef {(currentJob: Job | null, queue: Job[], newJob: Job) => Job[]} QueuingStrategy
+ */
+export type QueuingStrategy = (
+  currentJob: Job | null,
+  queue: Job[],
+  newJob: Job
+) => Job[];
+
+export const defaultQueuingStrategy: QueuingStrategy = (
+  currentJob: Job | null,
+  queue: Job[],
+  newJob: Job
+) => [...queue, newJob];
+
+/**
+ * `CortexScheduler` is a class that manages the execution of mental processes
+ * in a queue. It ensures that only one process runs at a time, and provides
+ * mechanisms for process registration, dispatching, and cancellation.
+ *
+ * @class CortexScheduler
+ *
+ * @method register: Used to register a new process in the CortexScheduler.
+ * @method dispatch: Adds a process to the queue and starts the process if
+ * the CortexScheduler is not currently running any process.
+ * @method run: Starts the execution of jobs in the queue. It dequeues the next
+ * job and runs the mental process. If an error occurs, it is logged and the
+ * next job is dequeued.
+ */
+export class CortexScheduler {
+  private processQueue: Job[] = [];
+  private currentJob: Job | null = null;
+  private processes = new Map<string, MentalProcess>();
+  private lastStep: CortexStep;
+  private readonly queuingStrategy = defaultQueuingStrategy;
+  private isRunning = false;
+  private mutex = new Mutex();
+
+  constructor(firstStep: CortexStep, options?: ManagerOptions) {
+    if (options?.queuingStrategy) {
+      this.queuingStrategy = options.queuingStrategy;
+    }
+    this.lastStep = firstStep;
+  }
+
+  register({ name, process }: ProcessConfig) {
+    this.processes.set(name, process);
+  }
+
+  async dispatch(name: string, newMemory: ChatMessage): Promise<void> {
+    const release = await this.mutex.acquire();
+    try {
+      const process = this.processes.get(name);
+      if (!process) throw new Error(`Process ${name} does not exist`);
+
+      const job: Job = {
+        process,
+        newMemory,
+        abortController: new AbortController(),
+        jobCompletion: (() => {
+          let resolve: () => void;
+          const promise = new Promise<void>((r) => {
+            resolve = r;
+          });
+          return { resolve: resolve!, promise };
+        })(),
+      };
+
+      this.processQueue = this.queuingStrategy(
+        this.currentJob,
+        this.processQueue,
+        job
+      );
+
+      if (!this.isRunning) {
+        this.isRunning = true;
+        this.run().catch((error) => {
+          console.error("Error in dispatch:", error);
+        });
+      }
+      return job.jobCompletion.promise;
+    } finally {
+      release();
+    }
+  }
+
+  private async run() {
+    let nextJob: Job | null = null;
+
+    do {
+      await this.mutex.runExclusive(() => {
+        nextJob = this.processQueue.shift() || null;
+        this.currentJob = nextJob;
+        this.isRunning = this.processQueue.length > 0;
+      });
+
+      if (nextJob) {
+        nextJob = nextJob as Job;
+        try {
+          this.lastStep = await nextJob.process(
+            nextJob.abortController.signal as AbortSignal,
+            nextJob.newMemory,
+            this.lastStep
+          );
+        } catch (error) {
+          console.error("Error in job process:", error);
+        } finally {
+          await this.mutex.runExclusive(() => {
+            this.currentJob = null;
+            nextJob?.jobCompletion?.resolve();
+          });
+        }
+      }
+    } while (nextJob);
+  }
+}

--- a/core/src/next/index.ts
+++ b/core/src/next/index.ts
@@ -1,4 +1,5 @@
 export * from './CortexStep';
+export * from './cortexScheduler'
 export * from './languageModels';
 export * from './cognitiveFunctions';
 export * from "./instrumentation";

--- a/core/tests/next/cortexScheduler.spec.ts
+++ b/core/tests/next/cortexScheduler.spec.ts
@@ -1,0 +1,54 @@
+import {
+  AbortSignal,
+} from "abort-controller";
+import { expect } from "chai";
+import { CortexScheduler, CortexStep, ChatMessageRoleEnum, ChatMessage, externalDialog, Job } from '../../src/next';
+
+describe("CortexScheduler", () => {
+  it("executes conversation", async () => {
+    const samanthaReplies = async (signal:AbortSignal, newMemory:ChatMessage, lastStep:CortexStep<any>) => {
+      let step = lastStep;
+      step = step.withMemory([newMemory]);
+      const shouts = await step.next(externalDialog("SHOUT IN ALL CAPS!"));
+      if (signal.aborted) {
+        return step;
+      } else {
+        console.log("Samantha says: ", shouts.value);
+        return shouts;
+      }
+    };
+    const abortQueuingStrategy = (currentJob:Job|null, queue:Job[], newJob:Job) => {
+      currentJob?.abortController?.abort();
+      return [newJob];
+    };
+    const samanthaRepliesConfig = {
+      name: "SamanthaReplies",
+      process: samanthaReplies,
+    };
+
+    const initialMemories = [
+      {
+        role: ChatMessageRoleEnum.System,
+        content: "<Context>You are modeling the mind of Samantha</Context>",
+      },
+    ];
+    let firstStep = new CortexStep("Samantha");
+    firstStep = firstStep.withMemory(initialMemories);
+    const cortex = new CortexScheduler(firstStep, {
+      queuingStrategy: abortQueuingStrategy,
+    });
+    cortex.register(samanthaRepliesConfig);
+
+    // dispatch without waiting for return
+    cortex.dispatch("SamanthaReplies", {
+      role: ChatMessageRoleEnum.User,
+      content: "Hello, Samantha!",
+    });
+
+    await cortex.dispatch("SamanthaReplies", {
+      role: ChatMessageRoleEnum.User,
+      content: "F U!",
+    });
+    expect(true).to.be.true;
+  });
+});

--- a/core/tests/shared/dotenv.ts
+++ b/core/tests/shared/dotenv.ts
@@ -1,0 +1,2 @@
+import dotenv from 'dotenv';
+dotenv.config();


### PR DESCRIPTION
Bringing in and fixing things in the /next section that are necessary to switch over example code in the docs.

* bring back the CortexScheduler in /next (and test it)
* Add prompts from some of our demos for internal/externalDialog
* rename `stringCommand` (mark existing as deprecated) to `instruction` as "stringCommand" is too close to implementation rather than function
* support taking a function for `instruction` so that the instruction has access to the entity name / memory, etc