### PR TITLE
simple z-index to get the popup over scroll bars

### DIFF
--- a/docs/src/components/ApiKeyPopup.css
+++ b/docs/src/components/ApiKeyPopup.css
@@ -73,6 +73,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  z-index: 10;
 }
 
 .popup {


### PR DESCRIPTION
SImple fix to stop the API key popup from getting covered up by the scroll bars.

![image](https://github.com/opensouls/SocialAGI/assets/1274/243e8da1-38ca-498c-9a75-423a569c4d30)
