### PR TITLE
bump versions

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "socialagi",
-  "version": "0.0.35-3",
+  "version": "0.0.35",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "socialagi",
-      "version": "0.0.35-3",
+      "version": "0.0.35",
       "license": "ISC",
       "dependencies": {
         "@opentelemetry/api": "^1.6.0",

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socialagi",
-  "version": "0.0.35-3",
+  "version": "0.0.35",
   "description": "Subroutines for AI Souls",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -25,7 +25,7 @@
         "react-ace": "^10.1.0",
         "react-dom": "^17.0.2",
         "react-icons": "^4.10.1",
-        "socialagi": "^0.0.35-3",
+        "socialagi": "^0.0.35",
         "stream-browserify": "^3.0.0",
         "stream-http": "^3.2.0",
         "url": "^0.11.3",
@@ -13720,9 +13720,9 @@
       }
     },
     "node_modules/socialagi": {
-      "version": "0.0.35-3",
-      "resolved": "https://registry.npmjs.org/socialagi/-/socialagi-0.0.35-3.tgz",
-      "integrity": "sha512-8YGy0Ytf+qyPnGHJy667mzjQF7AEab2gA8JVAg/CVbjbkGwy9hZ4VjiCCUeMfPSpAlw54c5trNMaL9FtDV3NQw==",
+      "version": "0.0.35",
+      "resolved": "https://registry.npmjs.org/socialagi/-/socialagi-0.0.35.tgz",
+      "integrity": "sha512-pN6shafGz8yJQslY1Yd8a5hDjJCH0Y1HBgcCTMSvepA3a8lQscJOxI4BvwWKmm6qY5aIb7YJ78b4r2WoeSOxSg==",
       "dependencies": {
         "@opentelemetry/api": "^1.6.0",
         "abort-controller": "^3.0.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -33,7 +33,7 @@
     "react-ace": "^10.1.0",
     "react-dom": "^17.0.2",
     "react-icons": "^4.10.1",
-    "socialagi": "^0.0.35-3",
+    "socialagi": "^0.0.35",
     "stream-browserify": "^3.0.0",
     "stream-http": "^3.2.0",
     "url": "^0.11.3",


### PR DESCRIPTION
I'll self merge this, but bumps the latest version of core to v0.0.35 (already published to npm) and uses that in docs.