### PR TITLE
ignore .vercel for deployment

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -18,3 +18,4 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.vercel


### PR DESCRIPTION
after you configure deployment for the docs, this gets added to the .gitignore so just checking this in. I will self merge this.