### PR TITLE
version bump and ignore @xenova/transformers in doc section

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -4,7 +4,6 @@
 const path = require("path");
 const lightCodeTheme = require("prism-react-renderer/themes/github");
 const darkCodeTheme = require("prism-react-renderer/themes/dracula");
-const webpack = require('webpack');
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -4,6 +4,7 @@
 const path = require("path");
 const lightCodeTheme = require("prism-react-renderer/themes/github");
 const darkCodeTheme = require("prism-react-renderer/themes/dracula");
+const webpack = require('webpack');
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -32,6 +33,8 @@ const config = {
     defaultLocale: "en",
     locales: ["en"],
   },
+
+  plugins: ["docusaurus-webpack"],
 
   clientModules: [path.resolve(__dirname, "src/plugins/vercelAnalytics.js")],
 

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -11,7 +11,7 @@
         "@docusaurus/core": "^2.4.3",
         "@docusaurus/preset-classic": "^2.4.3",
         "@mdx-js/react": "^1.6.22",
-        "@socialagi/memory": "^0.0.3-0",
+        "@socialagi/memory": "^0.0.3",
         "@vercel/analytics": "^1.0.1",
         "abort-controller": "^3.0.0",
         "browserify-zlib": "^0.2.0",
@@ -3750,9 +3750,9 @@
       }
     },
     "node_modules/@socialagi/memory": {
-      "version": "0.0.3-0",
-      "resolved": "https://registry.npmjs.org/@socialagi/memory/-/memory-0.0.3-0.tgz",
-      "integrity": "sha512-oF63+HVS3LYksOzfo4GvA6waY5bs8FJg3O75QxHZB0y2+IvhugJU1C16QERgOZuuhGSOn4PaF4OP5sFAvezjFQ==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@socialagi/memory/-/memory-0.0.3.tgz",
+      "integrity": "sha512-ehrmsp8gd9DYDvfm6lsQVXbqc3PHj37Z7CR31j372+SnBE2smQMmvteQPWUwAyIc7PZjWMBO5+EWubQxuMEw+g==",
       "dependencies": {
         "@opentelemetry/api": "^1.4.1",
         "@xenova/transformers": "^2.5.3",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -19,6 +19,7 @@
         "common-tags": "^1.8.2",
         "crypto-browserify": "^3.12.0",
         "docusaurus-plugin-webpack-crypto": "file:plugins/docusaurus-plugin-webpack-crypto",
+        "docusaurus-webpack": "file:plugins/docusaurus-webpack",
         "os-browserify": "^0.3.0",
         "path-browserify": "^1.0.1",
         "prism-react-renderer": "^1.3.5",
@@ -7404,6 +7405,10 @@
     },
     "node_modules/docusaurus-plugin-webpack-crypto": {
       "resolved": "plugins/docusaurus-plugin-webpack-crypto",
+      "link": true
+    },
+    "node_modules/docusaurus-webpack": {
+      "resolved": "plugins/docusaurus-webpack",
       "link": true
     },
     "node_modules/dom-converter": {
@@ -16998,6 +17003,10 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "plugins/docusaurus-plugin-webpack-crypto": {}
+    "plugins/docusaurus-plugin-webpack-crypto": {},
+    "plugins/docusaurus-webpack": {
+      "version": "1.0.0",
+      "license": "ISC"
+    }
   }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -19,7 +19,7 @@
     "@docusaurus/core": "^2.4.3",
     "@docusaurus/preset-classic": "^2.4.3",
     "@mdx-js/react": "^1.6.22",
-    "@socialagi/memory": "^0.0.3-0",
+    "@socialagi/memory": "^0.0.3",
     "@vercel/analytics": "^1.0.1",
     "abort-controller": "^3.0.0",
     "browserify-zlib": "^0.2.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -27,6 +27,7 @@
     "common-tags": "^1.8.2",
     "crypto-browserify": "^3.12.0",
     "docusaurus-plugin-webpack-crypto": "file:plugins/docusaurus-plugin-webpack-crypto",
+    "docusaurus-webpack": "file:plugins/docusaurus-webpack",
     "os-browserify": "^0.3.0",
     "path-browserify": "^1.0.1",
     "prism-react-renderer": "^1.3.5",

--- a/docs/plugins/docusaurus-webpack/index.js
+++ b/docs/plugins/docusaurus-webpack/index.js
@@ -1,0 +1,24 @@
+// A JavaScript function that returns an object.
+// `context` is provided by Docusaurus. Example: siteConfig can be accessed from context.
+// `opts` is the user-defined options.
+async function myPlugin(context, opts) {
+  console.warn("ignoring @xenova/transformers in webpack build")
+  return {
+    // A compulsory field used as the namespace for directories to cache
+    // the intermediate data for each plugin.
+    // If you're writing your own local plugin, you will want it to
+    // be unique in order not to potentially conflict with imported plugins.
+    // A good way will be to add your own project name within.
+    name: "docusaurus-webpack",
+
+    configureWebpack(config, isServer, utils) {
+      return {
+        externals: {
+          "@xenova/transformers": "empty",
+        },
+      };
+    },
+  };
+}
+
+module.exports = myPlugin;

--- a/docs/plugins/docusaurus-webpack/package.json
+++ b/docs/plugins/docusaurus-webpack/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "docusaurus-webpack",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/memory/package-lock.json
+++ b/memory/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@socialagi/memory",
-  "version": "0.0.3-0",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@socialagi/memory",
-      "version": "0.0.3-0",
+      "version": "0.0.3",
       "license": "ISC",
       "dependencies": {
         "@opentelemetry/api": "^1.4.1",

--- a/memory/package.json
+++ b/memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@socialagi/memory",
-  "version": "0.0.3-0",
+  "version": "0.0.3",
   "description": "",
   "files": [
     "dist"


### PR DESCRIPTION
Webpack can't handle the wasm or the models in there, so just ignore it since it's not used in the playground.