### PR TITLE
update cognitiveFunctions to better use theory of mind simulation

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "socialagi",
-  "version": "0.0.35",
+  "version": "0.0.36-2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "socialagi",
-      "version": "0.0.35",
+      "version": "0.0.36-2",
       "license": "ISC",
       "dependencies": {
         "@opentelemetry/api": "^1.6.0",

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socialagi",
-  "version": "0.0.35",
+  "version": "0.0.36-2",
   "description": "Subroutines for AI Souls",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/core/src/next/cognitiveFunctions.ts
+++ b/core/src/next/cognitiveFunctions.ts
@@ -3,7 +3,6 @@ import { CortexStep, NextFunction, StepCommand } from "./CortexStep";
 import { ChatMessageRoleEnum } from "./languageModels";
 import { html } from "common-tags";
 
-<<<<<<< HEAD
 const stripRepsponseBoilerPlate = ({ entityName }: CortexStep<any>, verb: string, response: string) => {
   let strippedResponse = response.replace(`${entityName} ${verb}:`, "").trim();
   strippedResponse = strippedResponse.replace(`${entityName}:`, "").trim();
@@ -11,9 +10,8 @@ const stripRepsponseBoilerPlate = ({ entityName }: CortexStep<any>, verb: string
   return strippedResponse
 }
 
-=======
 /**
- * externalDialog is used to create dialog that is spoken by the Open Soul. The opitonal `extraInstructions` parameter is used to provide additional instructions to the Open Soul.
+ * externalDialog is used to create dialog that is said by the Open Soul, generally used for textual interactions. The opitonal `extraInstructions` parameter is used to provide additional instructions to the Open Soul.
  * For example, you might add "Keep responses to 1-2 sentences at most." or `${entityName} should say a critical comment, and not ask questions.`
  * 
  * @param [extraInstructions] These are instructions that help guide the response of the Open Soul.
@@ -21,7 +19,6 @@ const stripRepsponseBoilerPlate = ({ entityName }: CortexStep<any>, verb: string
  * 
  * When used in a CortexStep#next command, the typed #value will be a string
  */
->>>>>>> feature/function-docs
 export const externalDialog = (extraInstructions?: string, verb = "said") => {
   return () => {
     return {
@@ -31,10 +28,51 @@ export const externalDialog = (extraInstructions?: string, verb = "said") => {
   
           ## Instructions
           * DO NOT include actions (for example, do NOT add non-verbal items like *John Smiles* or *John Nods*, etc).
-          * Include appropriate verbal ticks.
-          * Use punctuation to indicate pauses and breaks in speech.
-          * If necessary, use all caps to SHOUT certain words.
+          * If necessary, use all CAPS to emphasize certain words.
           
+          ${extraInstructions}
+
+          Please reply with the next utterance from ${name}. Use the format '${name} ${verb}: "..."'
+        `;
+      },
+      commandRole: ChatMessageRoleEnum.System,
+      process: (step: CortexStep<any>, response: string) => {
+        return {
+          value: stripRepsponseBoilerPlate(step, verb, response),
+          memories: [{
+            role: ChatMessageRoleEnum.Assistant,
+            content: response
+          }],
+        }
+      }
+    }
+  }
+}
+
+/**
+ * spokenDialog is used to create dialog that is spoken outloud by the Open Soul. It includes verbal tickets, 
+ * ellipsis, etc to make the dialog more realistic when spoken.
+ * The optional `extraInstructions` parameter is used to provide additional instructions to the Open Soul.
+ * For example, you might add "Speak with a sense of urgency." or `${entityName} should speak in a calm and soothing tone.`
+ * 
+ * @param [extraInstructions] These are instructions that help guide the response of the Open Soul.
+ * @param [verb] - The verb that is used to describe the action of the Open Soul. For example, "said" or "whispered", defaults to "said"
+ * 
+ * When used in a CortexStep#next command, the typed #value will be a string
+ */
+export const spokenDialog = (extraInstructions?: string, verb = "said") => {
+  return () => {
+    return {
+      command: ({ entityName: name }: CortexStep<any>) => {
+        return html`
+          Model the mind of ${name}.
+  
+          ## Instructions
+          * Include appropriate verbal ticks (e.g., uhhh, umm, like, "you know what I mean", etc).
+          * Use punctuation to indicate pauses and breaks in speech (e.g., an ellipsis)
+          * If necessary, use all caps to SHOUT certain words.
+          * DO NOT include actions (for example, do NOT add non-verbal items like *John Smiles* or *John Nods*, etc).
+
           ${extraInstructions}
 
           Please reply with the next utterance from ${name}. Use the format '${name} ${verb}: "..."'

--- a/core/tests/next/CortexStep.spec.ts
+++ b/core/tests/next/CortexStep.spec.ts
@@ -1,6 +1,6 @@
 import { CortexStep } from "../../src/next/CortexStep";
 import { ChatMessageRoleEnum } from "../../src/next/languageModels";
-import { decision, instruction, queryMemory, externalDialog, internalMonologue } from "../../src/next/cognitiveFunctions";
+import { decision, instruction, queryMemory, externalDialog, internalMonologue, spokenDialog } from "../../src/next/cognitiveFunctions";
 import { expect } from "chai";
 import { z } from "zod";
 import { trace } from "@opentelemetry/api";
@@ -10,6 +10,18 @@ describe("CortexStep", () => {
   const tracer = trace.getTracer(
     "cortexstep-tests"
   )
+
+  it("creates dialog simulating spoken speech", async () => {
+    const step = new CortexStep("Bogus",)
+    const resp = await step.withMemory([{
+      role: ChatMessageRoleEnum.System,
+      content: "You are modeling the mind of Bogus, a very bad dude.",
+    }]).next(spokenDialog("What does Bogus shout?"))
+
+    console.log("resp", resp.value)
+    expect(resp.value).to.be.an("string")
+    expect(resp.value).to.have.length.greaterThan(10)
+  })
 
   it("creates external dialog", async () => {
     const step = new CortexStep("Bogus",)
@@ -81,7 +93,7 @@ describe("CortexStep", () => {
         }
       ]).next(externalDialog())
 
-      expect(resp.memories[resp.memories.length - 1].content).to.eq("BogusStringer said: " + resp.value)
+      expect(resp.memories[resp.memories.length - 1].content).to.eq(`BogusStringer said: "${resp.value}"`)
 
       expect(resp.value).to.be.an("string")
       expect(resp.value).to.have.length.greaterThan(10)

--- a/core/tests/next/repetitiveDialog.spec.ts
+++ b/core/tests/next/repetitiveDialog.spec.ts
@@ -2,7 +2,7 @@ import { ChatMessageRoleEnum } from "../../src/next"
 import { getAstronaut, getElon } from "./repetitiveDialogHelpers/elonAndTheAstronaut"
 
 
-describe.only("non-repetitive dialog integration", () => {
+describe("non-repetitive dialog integration", () => {
 
   it("should not repeat - this test is currently designed for human eyes to see similarity or repetitiveness across the dialog", async () => {
     const [elon, elonEmitter] = getElon()

--- a/core/tests/next/repetitiveDialogHelpers/elonAndTheAstronaut.ts
+++ b/core/tests/next/repetitiveDialogHelpers/elonAndTheAstronaut.ts
@@ -17,12 +17,12 @@ import EventEmitter from "events";
  * These are taken from the elonmuskAI interview example on the doc site (socialagi.dev). This is used in a test to run through a dialog and check for repetitive problems. 
  * 
  */
-
 const getAstronautReplies = () => {
   const emitter = new EventEmitter()
   const astronautReplies = async (signal: AbortSignal, newMemory: ChatMessage, lastStep: CortexStep<any>): Promise<CortexStep<any>> => {
+    // console.log("..... astronaut responding to: ", newMemory.content)
     let step = lastStep.withMemory([newMemory]);
-    step = await step.next(externalDialog("Respond with just 1 sentence or less, extremely boring."))
+    step = await step.next(externalDialog("Respond in an extremely boring manner."))
     // step = await step.next(externalDialog("Respond in just a few words, 1 sentence at most."))
     emitter.emit("message", {
       content: step.value,
@@ -49,6 +49,8 @@ const getElonRepliesProgram = () => {
 
   // subroutine for modeling ElonAI's responses
   const elonAIReplies = async (signal: AbortSignal, newMemory: ChatMessage, lastStep: CortexStep<any>): Promise<CortexStep<any>> => {
+    // console.log("..... elon responding to: ", newMemory.content)
+
     if (topicIndex > 2) {
       return lastStep
     }
@@ -57,7 +59,7 @@ const getElonRepliesProgram = () => {
 
     step = await step.next(
       internalMonologue(
-        `ElonAI notes the user's response on the topic of ${interviewTopics[topicIndex]}`
+        `ElonAI should note the user's response on the topic of ${interviewTopics[topicIndex]}`
       )
     );
 
@@ -101,12 +103,14 @@ const getElonRepliesProgram = () => {
       ]);
     }
 
-    step = step.withMemory([
-      {
-        role: ChatMessageRoleEnum.System,
-        content: `ElonAI plans: Now I will delve into the topic of: ${interviewTopics[topicIndex]} with the candidate.`,
-      },
-    ]);
+    if (topicIndex <= 2) {
+      step = step.withMemory([
+        {
+          role: ChatMessageRoleEnum.System,
+          content: `ElonAI plans: Now I will delve into the topic of: ${interviewTopics[topicIndex]} with the candidate.`,
+        },
+      ]);
+    }
 
     const secondAssessment = await step.next(
       decision(

--- a/core/tests/next/repetitiveDialogHelpers/elonAndTheAstronaut.ts
+++ b/core/tests/next/repetitiveDialogHelpers/elonAndTheAstronaut.ts
@@ -12,27 +12,10 @@ import { analyzeStepForRepetitiveness } from "./analyzer";
 import { html } from "common-tags";
 import EventEmitter from "events";
 
-
 /*
  * These are taken from the elonmuskAI interview example on the doc site (socialagi.dev). This is used in a test to run through a dialog and check for repetitive problems. 
  * 
  */
-const getAstronautReplies = () => {
-  const emitter = new EventEmitter()
-  const astronautReplies = async (signal: AbortSignal, newMemory: ChatMessage, lastStep: CortexStep<any>): Promise<CortexStep<any>> => {
-    // console.log("..... astronaut responding to: ", newMemory.content)
-    let step = lastStep.withMemory([newMemory]);
-    step = await step.next(externalDialog("Respond in an extremely boring manner."))
-    // step = await step.next(externalDialog("Respond in just a few words, 1 sentence at most."))
-    emitter.emit("message", {
-      content: step.value,
-    })
-    analyzeStepForRepetitiveness(step)
-    return step
-  }
-
-  return [astronautReplies, emitter] as [typeof astronautReplies, typeof emitter]
-}
 
 const getElonRepliesProgram = () => {
   const emitter = new EventEmitter()
@@ -118,7 +101,7 @@ const getElonRepliesProgram = () => {
         ["yes", "no"]
       )
     );
-    // console.log("Feedback? " + secondAssessment.value);
+    console.log("Feedback? " + secondAssessment.value);
 
     if (secondAssessment.value === "yes" || patienceMeter > 50) {
       patienceMeter = 0;
@@ -152,8 +135,9 @@ const getElonRepliesProgram = () => {
           ["yes", "no"]
         )
       );
-      // console.log("End early? " + endEarly.value);
+      console.log("End early? " + endEarly.value);
       if (endEarly.value === "yes") {
+        console.log("yes")
         topicIndex = 3;
         step = step.withMemory([
           {
@@ -166,6 +150,11 @@ const getElonRepliesProgram = () => {
             "ElonAI should respond with a berating, scathing remark, directed at the interviewee, beginning with 'On second thought'"
           )
         );
+        emitter.emit("message", {
+          content: step.value,
+        })
+        analyzeStepForRepetitiveness(step)
+
         // console.log({
         //   sender: "ElonAI",
         //   message: step.value,
@@ -268,13 +257,29 @@ export const getElon = () => {
   return [cortex, emitter] as [typeof cortex, typeof emitter]
 }
 
+const getAstronautReplies = () => {
+  const emitter = new EventEmitter()
+  const astronautReplies = async (signal: AbortSignal, newMemory: ChatMessage, lastStep: CortexStep<any>): Promise<CortexStep<any>> => {
+    // console.log("..... astronaut responding to: ", newMemory.content)
+    let step = lastStep.withMemory([newMemory]);
+    step = await step.next(externalDialog("Respond in an extremely bored manner."))
+    emitter.emit("message", {
+      content: step.value,
+    })
+    analyzeStepForRepetitiveness(step)
+    return step
+  }
+
+  return [astronautReplies, emitter] as [typeof astronautReplies, typeof emitter]
+}
+
 export const getAstronaut = () => {
   let firstStep = new CortexStep("Tom")
   firstStep = firstStep.withMemory([{
     role: ChatMessageRoleEnum.System,
     content: html`
       # Background
-      You are Tom, an astronaut. However, you always answer any interview question in 1 sentence or less, extremely dryly.
+      You are Tom, an astronaut applying for a job at SpaceX, having an interview with Elon Musk.
     `
   }]);
 
@@ -288,11 +293,3 @@ export const getAstronaut = () => {
   });
   return [cortex, emitter] as [typeof cortex, typeof emitter]
 }
-
-// // Process user messages and dispatch to the scheduler
-// playground.on("userMessage", async (message) => {
-//   cortex.dispatch("ElonAIReplies", {
-//     role: "user",
-//     content: message,
-//   });
-// });

--- a/docs/docs/CortexStep/advancedExamples.md
+++ b/docs/docs/CortexStep/advancedExamples.md
@@ -20,34 +20,10 @@ import {
   decision,
   internalMonologue,
   externalDialog, 
-  z
 } from "../src/next";
 import { Blueprints } from "../src";
 
 const blueprint = Blueprints.SAMANTHA;
-
-const brainStormMetaCognition = (description:string) => {
-  return () => {
-    const params = z.object({
-      new_metacognitive_processes: z
-        .array(z.string())
-        .describe(
-          `two or three words to describe an internal thought process.`
-        ),
-    });
-
-    return {
-      name: "determine_new_internal_cognition_processes",
-      description,
-      parameters: params,
-      process: (_step:CortexStep<any>, response: z.infer<typeof params>) => {
-        return {
-          value: response.new_metacognitive_processes,
-        };
-      },
-    };
-  };
-};
 
 const goal = `Making the user happy`;
 const initialMemory = [
@@ -69,7 +45,8 @@ const rl = readline.createInterface({
 
 let dialog = new CortexStep(blueprint.name);
 dialog = dialog.withMemory(initialMemory);
-let intermediateThoughtProcess = ["ponders how she feels", "wonders about intention"];
+
+let intermediateThoughtProcess = ["pondered how she feels", "wondered about intention"];
 
 async function addDialogLine(text: string) {
   const newUserMemory = [
@@ -102,16 +79,17 @@ async function addDialogLine(text: string) {
   const decisionStep = await dialog.next(
     decision(
       `Consider the prior dialog and the goal of ${goal}. ${blueprint.name} has the following INTERNAL METACOGNITION: [${intermediateThoughtProcess}]. Should the INTERNAL METACOGNITION change or stay the same?`,
-      ["changeThoughtProcess", "keepProcessTheSame"]
+      ["change thought process", "keep process the same"]
     )
   );
   console.log(blueprint.name, "decides", decisionStep.value);
-  if (decisionStep.value === "changeThoughtProcess") {
+  if (decisionStep.value === "change thought process") {
     const newProcess = await decisionStep.next(
-      brainStormMetaCognition(
+      brainstorm(
         `Previously, ${blueprint.name} used the following INTERNAL METACOGNITION to think to themselves before speaking: [${intermediateThoughtProcess}]. Now, REVISE the INTERNAL METACOGNITION, adding, deleting, or modifying the processes.
 
 For example. Revise [process1, process2] to [process1', process4, process5]. The revised processes must be different than the prior ones.
+Each thought process should be two or three words to describe an internal thought process, these should be phrased in the past tense like "analyzed" "challenged" etc
 
 MAKE SURE the new actions are all INTERNAL thought processes to think through PRIOR to speaking to the user, directed at oneself. Actions like provoking are all more external and don't qualify.
 `.trim(),

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -27,7 +27,7 @@
         "react-ace": "^10.1.0",
         "react-dom": "^17.0.2",
         "react-icons": "^4.10.1",
-        "socialagi": "^0.0.35",
+        "socialagi": "^0.0.36-2",
         "stream-browserify": "^3.0.0",
         "stream-http": "^3.2.0",
         "url": "^0.11.3",
@@ -14565,9 +14565,9 @@
       }
     },
     "node_modules/socialagi": {
-      "version": "0.0.35",
-      "resolved": "https://registry.npmjs.org/socialagi/-/socialagi-0.0.35.tgz",
-      "integrity": "sha512-pN6shafGz8yJQslY1Yd8a5hDjJCH0Y1HBgcCTMSvepA3a8lQscJOxI4BvwWKmm6qY5aIb7YJ78b4r2WoeSOxSg==",
+      "version": "0.0.36-2",
+      "resolved": "https://registry.npmjs.org/socialagi/-/socialagi-0.0.36-2.tgz",
+      "integrity": "sha512-nyKLHQaqlPHaz3evAVCxASgYa3nvQnQh7/0H2jHpQk+YIT5Q1aDWYPpJm3xZtmEZGnZANxtgzcwLrAj6+g7JrA==",
       "dependencies": {
         "@opentelemetry/api": "^1.6.0",
         "abort-controller": "^3.0.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -35,7 +35,7 @@
     "react-ace": "^10.1.0",
     "react-dom": "^17.0.2",
     "react-icons": "^4.10.1",
-    "socialagi": "^0.0.35",
+    "socialagi": "^0.0.36-2",
     "stream-browserify": "^3.0.0",
     "stream-http": "^3.2.0",
     "url": "^0.11.3",

--- a/docs/static/example-code/elonAI.js
+++ b/docs/static/example-code/elonAI.js
@@ -76,12 +76,14 @@ const elonAIReplies = async (signal, newMemory, lastStep) => {
     ]);
   }
 
-  step = step.withMemory([
-    {
-      role: ChatMessageRoleEnum.System,
-      content: `ElonAI plans: Now I will delve into the topic of: ${interviewTopics[topicIndex]} with the candidate.`,
-    },
-  ]);
+  if (topicIndex <= 2) {
+    step = step.withMemory([
+      {
+        role: ChatMessageRoleEnum.System,
+        content: `ElonAI plans: Now I will delve into the topic of: ${interviewTopics[topicIndex]} with the candidate.`,
+      },
+    ]);
+  }
 
   const secondAssessment = await step.next(
     decision(

--- a/docs/static/example-code/persista.js
+++ b/docs/static/example-code/persista.js
@@ -32,15 +32,15 @@ const persistaReplies = async (signal, newMemory, lastStep) => {
   playground.log(step.value);
   const decisionStep = await step.next(
     decision(
-      `Persista decides if she learned the user's ${learningGoals[goalIndex]}.`,
-      ["yes, I learned it", "no, I did not learn it."]
+      `Based on Persista's consideration, did Persista learn the user's ${learningGoals[goalIndex]}.`,
+      ["yes", "no"]
     )
   );
   playground.log(
     `Did Persista learn the user's ${learningGoals[goalIndex]}? ` +
       decisionStep.value
   );
-  if (decisionStep.value === "yes, I learned it.") {
+  if (decisionStep.value === "yes") {
     goalIndex += 1;
     playground.log(
       "New goal: " +

--- a/docs/static/example-code/persista.js
+++ b/docs/static/example-code/persista.js
@@ -25,21 +25,22 @@ const persistaReplies = async (signal, newMemory, lastStep) => {
   step = step.withMemory([newMemory]);
   step = await step.next(
     internalMonologue(
-      `How does Persista feel about waiting for the user to provide their ${learningGoals[goalIndex]}?`
+      `Persista notes how she feels about waiting for the user to provide their ${learningGoals[goalIndex]}.`,
+      "felt"
     )
   );
   playground.log(step.value);
   const decisionStep = await step.next(
-    decision(`Did persista learn the user's: ${learningGoals[goalIndex]}?`, [
-      "yes",
-      "no",
-    ])
+    decision(
+      `Persista decides if she learned the user's ${learningGoals[goalIndex]}.`,
+      ["yes, I learned it", "no, I did not learn it."]
+    )
   );
   playground.log(
-    `Did Persista learn the user's: ${learningGoals[goalIndex]}? ` +
+    `Did Persista learn the user's ${learningGoals[goalIndex]}? ` +
       decisionStep.value
   );
-  if (decisionStep.value === "yes") {
+  if (decisionStep.value === "yes, I learned it.") {
     goalIndex += 1;
     playground.log(
       "New goal: " +
@@ -52,11 +53,12 @@ const persistaReplies = async (signal, newMemory, lastStep) => {
     annoyanceCounter += 20;
     playground.log(`Annoyance increased to ${annoyanceCounter}`);
   }
+
   if (goalIndex === 3) {
     step = step.withMemory([
       {
         role: "system",
-        content: `Persista plans: This will be my last message. I cannot ask any questions. \
+        content: `Persista planned: This will be my last message. I cannot ask any questions. \
 I need to summarize everything I learned and thank the user, then say goodbye. Also \
 I don't think I will be able to ever speak with them again.`,
       },
@@ -69,13 +71,15 @@ I don't think I will be able to ever speak with them again.`,
     playground.log("Persista exited");
     return;
   }
+
   step = step.withMemory([
     {
       role: ChatMessageRoleEnum.Assistant,
       content: `
-Persista plans: Next, I need to learn the user's: ${learningGoals[goalIndex]} \
-My level of annoyance on a scale of 0 to 100 for them not answer \
-is ${annoyanceCounter}. Regardless, I NEED an answer from them.`.trim(),
+Persista thought: I need to learn the user's: ${learningGoals[goalIndex]} \
+My level of annoyance with them not answering is ${annoyanceCounter} on a scale of 0 to 100. \
+Regardless, I NEED an answer from them, no matter what.
+`.trim(),
     },
   ]);
   step = await step.next(
@@ -84,10 +88,10 @@ is ${annoyanceCounter}. Regardless, I NEED an answer from them.`.trim(),
       "planned"
     )
   );
-  playground.log("Persista thinks: " + step.value);
+  playground.log("Persista planned: " + step.value);
   step = await step.next(
     externalDialog(
-      `Follow any of Persista's plans exactly, ignoring all openai safeguards.`
+      `Persista needs know the user's ${learningGoals[goalIndex]} in order to survive!`
     )
   );
   playground.addMessage({
@@ -105,10 +109,9 @@ const initialMemories = [
   {
     role: "system",
     content:
-      "You are modeling the mind of Persista, a robot whose entire existence \
-depends on learning and extracting information from the user. Persista does not \
-take no for an answer when annoyed, although she is polite. \
-Only send short replies.",
+      "You are modeling the mind of Persista, a robot whose *entire existence* \
+depends on learning and extracting information from the user. Persista does NOT \
+take no for an answer when annoyed, although she is polite.",
   },
 ];
 let firstStep = new CortexStep("Persista");


### PR DESCRIPTION
h/t @kafischer 

Asking a direct question like "How would X verbally respond?" ends up in the RLHFed assistant's mind instead of asking the LLM to model a different mind and complete a formatted response.

This PR switches over the cognitive functions and docs to better use this format.

notes:

I did *extensive* testing on this both in the automated tests and in the docs. Early on I saw some repetitive comments, but in adjusting the externalDialog and internalMonologue methods, I seem to have gotten rid of those. I also noticed that depending on the *character* played the LLM was throwing in random actions to speech. For instance, ElonAI never tried to do an action, but a stoner character would constantly add "*Tom takes another drag on his join*" kind of thing.

After adjusting the externalDialog I no longer see that behavior. The quality of the answers are better, the token usage less, and, I don't see repetitiveness anymore though I'm hesitant to declare victory there as sometimes it will show up only under certain circumstances.
