### PR TITLE
change how we handle oss models that only handle a single system message

### DIFF
--- a/core/tests/next/languageModels/functionlessLLM.spec.ts
+++ b/core/tests/next/languageModels/functionlessLLM.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import { ChatMessageRoleEnum } from "../../../src";
-import { CortexStep, z } from "../../../src/next";
+import { CortexStep, decision, externalDialog, internalMonologue, queryMemory, z } from "../../../src/next";
 import { FunctionlessLLM } from "../../../src/next/languageModels/FunctionlessLLM";
 
 // this is set to skip because it requires a locally running LLM server.
@@ -47,7 +47,7 @@ describe.skip("FunctionlessLLM", () => {
     let step = new CortexStep("Jonathan", {
       processor: new FunctionlessLLM({
         baseURL: "http://localhost:1234/v1",
-        compressSystemMessages: true,
+        singleSystemMessage: true,
       })
     });
     step = step.withMemory([{
@@ -57,5 +57,55 @@ describe.skip("FunctionlessLLM", () => {
     const resp = await step.next(queryMemory("What is the name I'm looking for? Answer in a single word"))
     expect(resp.value.answer).to.equal("Jonathan")
   }).timeout(65_000)
+
+
+  it.only('does a long bogus monologue', async () => {
+    try {
+      const memory = [
+        {
+          role: ChatMessageRoleEnum.System,
+          content:
+            "You are modeling the mind of Bogus, an evil entity that eats children",
+        },
+        {
+          role: ChatMessageRoleEnum.User,
+          content: "hi",
+        },
+      ];
+      const monologue = new CortexStep("Bogus", {
+        processor: new FunctionlessLLM({
+          baseURL: "http://localhost:1234/v1",
+          singleSystemMessage: true,
+        })
+      }).withMemory(memory)
+
+      enum BogusAction {
+        stop = "stop",
+        rambles = "rambles",
+      }
+
+      const feels = await monologue.next(internalMonologue("Bogus notes how it feels to themself in one sentence"))
+      const thinks = await feels.next(internalMonologue("What does Bogus think to themself in one sentence"))
+      const says = await thinks.next(externalDialog("What does Bogus says out loud next"))
+      const action = await says.next(decision("Decide Bogus' next course of action in the dialog. Should he ramble or stop?", BogusAction))
+      if (action.value === BogusAction.rambles) {
+        const rambles = await action.next(externalDialog("Bogus rambles for two sentences out loud, extending his last saying"))
+        const shouts = await rambles.next(externalDialog("Bogus shouts incredibly loudly with all caps"))
+        const exclaims = await shouts.next(externalDialog("Bogus exclaims!"))
+        const continues = await exclaims.next(externalDialog("Bogus continues"))
+        console.log(continues.toString());
+        const query = (await continues.next(queryMemory("Please provide a summary of everything Bogus said"))).value
+        console.log(query)
+        expect(query).to.have.length.greaterThan(10)
+      } else {
+        console.log(action.toString())
+        const query = (await action.next(queryMemory("Please provide a summary of everything Bogus said"))).value
+        console.log(query)
+        expect(query).to.have.length.greaterThan(10)
+      }
+    } catch (err: any) {
+      expect(err).to.not.exist
+    }
+  })
 
 })


### PR DESCRIPTION
This was the work I needed to do to make the Open Hermes 2.5 Mistral code work well. They only support a single system message, but rather than compress those all to the top, we instead change extra system messages to user messages. This seems to work really well for the various OSS models that I tested with single system message support.