### PR TITLE
add a compute function that is similar to #next

### DIFF
--- a/core/src/next/CortexStep.ts
+++ b/core/src/next/CortexStep.ts
@@ -325,7 +325,19 @@ export class CortexStep<LastValueType = undefined> {
   }
 
   /**
-   * This function is used to execute the next step in the process.
+   * compute is very similar to #next, but returns only a value, and NOT a new CortexStep with new memories. 
+   * Nothing is modified on this CortexStep.
+   */
+  async compute<ParsedArgumentType, ProcessFunctionReturnType = undefined>(
+    functionFactory: NextFunction<LastValueType, ParsedArgumentType, ProcessFunctionReturnType>,
+    opts: NextOptions = {}
+  ): Promise<ProcessFunctionReturnType extends undefined ? ParsedArgumentType : ProcessFunctionReturnType> {
+    const step = await this.next(functionFactory, opts)
+    return step.value as any
+  }
+
+  /**
+   * next is used to execute CognitiveFunctions on this CortexStep.
    * @param functionFactory - A factory function that returns a cognitive function.
    * @param opts - An optional parameter that can be used to pass per request options and tags
    * @returns - Returns a Promise that resolves to a CortexStep object.

--- a/core/tests/next/CortexStep.spec.ts
+++ b/core/tests/next/CortexStep.spec.ts
@@ -1,5 +1,5 @@
 import { CortexStep } from "../../src/next/CortexStep";
-import { ChatMessageRoleEnum, FunctionlessLLM, OpenAILanguageProgramProcessor } from "../../src/next/languageModels";
+import { ChatMessageRoleEnum } from "../../src/next/languageModels";
 import { decision, instruction, queryMemory, externalDialog, internalMonologue, spokenDialog } from "../../src/next/cognitiveFunctions";
 import { expect } from "chai";
 import { z } from "zod";
@@ -7,7 +7,7 @@ import { trace } from "@opentelemetry/api";
 import { html } from "common-tags";
 import { angelDevilConversation } from "./exampleAngelDevilConversation";
 
-describe("CortexStep", () => {
+describe.only("CortexStep", () => {
 
   const tracer = trace.getTracer(
     "cortexstep-tests"
@@ -248,6 +248,17 @@ describe("CortexStep", () => {
     }])
     const resp = await step.next(queryMemory("What is the name I'm looking for? Answer in a single word"))
     expect(resp.value.answer).to.equal("Jonathan")
+  })
+
+  it('returns a value when using compute', async () => {
+    const step = new CortexStep("Bogus").withMemory([{
+      role: ChatMessageRoleEnum.System,
+      content: "You are modeling the mind of Bogus, a very bad dude.",
+    }])
+
+    const val = await step.compute(decision("Are you bogus?", ["yes", "no"]))
+
+    expect(val).to.equal("yes")
   })
 
   it('does a long bogus monologue', async () => {


### PR DESCRIPTION
This adds #compute to CortexStep which is very similar to #next, but instead returns just the value from the CognitiveFunction instead of a new CortexStep with new memories.