### PR TITLE
streaming support in a non-experimental way

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -41,6 +41,26 @@ const step = new CortexStep("EntityName");
 const nextStep = await step.next(cognitiveFunction);
 ```
 
+Streaming is fully supported:
+
+```typescript
+const step = new CortexStep("EntityName");
+const { stream, nextStep } = await step.next(cognitiveFunction, { stream: true });
+
+let streamed = ""
+
+// stream is an AsyncIterable<string>
+for await (const chunk of stream) {
+  expect(chunk).to.be.a("string")
+  expect(chunk).to.exist
+  streamed += chunk
+}
+// nextStep is a Promise<CortexStep> that resolves when the stream is complete.
+const resp = await nextStep
+```
+
+Process functions from cogntivie functions (see below) run _after_ the stream is complete.
+
 ### Cognitive Functions
 
 Cognitive functions are used to generate responses. They are based on OpenAI's function calling model and use Zod to provide strongly typed output and text formatting. The project includes several built in cognitive functions:

--- a/core/README.md
+++ b/core/README.md
@@ -45,7 +45,7 @@ Streaming is fully supported:
 
 ```typescript
 const step = new CortexStep("EntityName");
-const { stream, nextStep } = await step.next(cognitiveFunction, { stream: true });
+const { stream, nextStep } = await step.next(externalDialog("Say hello to the user!"), { stream: true });
 
 let streamed = ""
 

--- a/core/README.md
+++ b/core/README.md
@@ -59,7 +59,7 @@ for await (const chunk of stream) {
 const resp = await nextStep
 ```
 
-Process functions from cogntivie functions (see below) run _after_ the stream is complete.
+Process functions from cognitive functions (see below) run _after_ the stream is complete.
 
 ### Cognitive Functions
 

--- a/core/src/cognitiveFunctions.ts
+++ b/core/src/cognitiveFunctions.ts
@@ -224,7 +224,6 @@ export const brainstorm = (description: string) => {
 
 export const queryMemory = (query: string) => {
   return () => {
-    // Define a Zod schema for the expected structure
     const params = z.object({
       answer: z.string().describe(`The answer to: ${query}`)
     });
@@ -232,7 +231,7 @@ export const queryMemory = (query: string) => {
     return {
       name: "query_memory",
       description: query,
-      parameters: params, // This should now be a Zod schema
+      parameters: params,
       command: html`
         Do not repeat ${query} and instead use the dialog history.
         Do not copy sections of the chat history as an answer.

--- a/core/src/cognitiveFunctions.ts
+++ b/core/src/cognitiveFunctions.ts
@@ -188,7 +188,7 @@ export const decision = (description: string, choices: EnumLike | string[]) => {
  * 
  * When used in a CortexStep#next command, the typed #value will be a string[]
  */
-export const brainstorm = (description: string):NextFunction<string[], { new_ideas: string[] }, string[]> => {
+export const brainstorm = (description: string) => {
   return ({ entityName }: CortexStep<any>) => {
     const params = z.object({
       new_ideas: z.array(z.string()).describe(`The new ideas that ${entityName} brainstormed.`)
@@ -222,8 +222,8 @@ export const brainstorm = (description: string):NextFunction<string[], { new_ide
   }
 }
 
-export const queryMemory = (query: string): NextFunction<string, { answer: string }, string> => {
-  const func = ():BrainFunction<string, { answer: string }, string > => {
+export const queryMemory = (query: string) => {
+  return () => {
     // Define a Zod schema for the expected structure
     const params = z.object({
       answer: z.string().describe(`The answer to: ${query}`)
@@ -254,8 +254,6 @@ export const queryMemory = (query: string): NextFunction<string, { answer: strin
       }
     };
   }
-
-  return func
 }
 
 /**
@@ -263,7 +261,7 @@ export const queryMemory = (query: string): NextFunction<string, { answer: strin
  * Instead, these instructions are inserted directly into the dialog. 
  * However, they are removed when the answer is returned.
  */
-export const instruction = (command: StepCommand): NextFunction<unknown, string, string> => {
+export const instruction = (command: StepCommand): NextFunction<string, string> => {
   return () => {
     return {
       command,

--- a/core/src/cognitiveFunctions.ts
+++ b/core/src/cognitiveFunctions.ts
@@ -1,5 +1,5 @@
 import { EnumLike, z } from "zod"
-import { BrainFunction, CortexStep, NextFunction, StepCommand } from "./CortexStep";
+import { CortexStep, NextFunction, StepCommand } from "./CortexStep";
 import { ChatMessageRoleEnum } from "./languageModels";
 import { html } from "common-tags";
 

--- a/core/src/languageModels/FunctionlessLLM.ts
+++ b/core/src/languageModels/FunctionlessLLM.ts
@@ -162,29 +162,6 @@ export class FunctionlessLLM
     }
   }
 
-  experimentalStreamingExecute<FunctionCallReturnType = undefined>(
-    _messages: ChatMessage[],
-    _completionParams: LanguageModelProgramExecutorExecuteOptions = {},
-    _functions: FunctionSpecification[] = [],
-    _requestOptions: RequestOptions = {},
-    _retryError: RetryInformation | undefined = undefined
-  ): Promise<{
-    response: Promise<ExecutorResponse<FunctionCallReturnType>>,
-    stream: AsyncIterable<string>,
-  }> {
-    return tracer.startActiveSpan('experimentalStreamingExecute', async (span) => {
-      try {
-        throw new Error("at this time, streaming is not supported in the OSS models")
-      } catch (err: any) {
-        span.recordException(err);
-        console.error('error in execute', err);
-        throw err;
-      } finally {
-        span.end();
-      }
-    })
-  }
-
   async executeAlternativeFunctionPath<FunctionCallReturnType = undefined>(
     messages: ChatMessage[],
     completionParams: LanguageModelProgramExecutorExecuteOptions = {},
@@ -293,7 +270,11 @@ export class FunctionlessLLM
     functions: FunctionSpecification[] = [],
     requestOptions: RequestOptions = {},
     retryError: RetryInformation | undefined = undefined
-  ): Promise<ExecutorResponse> {
+  ): Promise<any> {
+    if (requestOptions.stream) {
+      throw new Error("streaming is not currently supported")
+    }
+
     return tracer.startActiveSpan('execute', async (span) => {
       try {
         const { functionCall, ...restRequestParams } = completionParams;

--- a/core/src/languageModels/index.ts
+++ b/core/src/languageModels/index.ts
@@ -19,6 +19,21 @@ export type Headers = Record<string, string | null | undefined>;
 export interface RequestOptions {
   signal?: AbortSignal | null;
   headers?: Headers;
+  stream?: boolean
+}
+  
+export interface RequestOptionsStreaming extends RequestOptions {
+  stream: true;
+}
+
+export interface RequestOptionsNonStreaming extends RequestOptions {
+  stream?: false;
+}
+
+export type NonStreamingExecuteResponse<FunctionCallReturnType = undefined> = ExecutorResponse<FunctionCallReturnType>
+export type StreamingExecuteResponse<FunctionCallReturnType = undefined> =  {
+  response: Promise<ExecutorResponse<FunctionCallReturnType>>,
+  stream: AsyncIterable<string>,
 }
 
 /**
@@ -29,23 +44,15 @@ export interface LanguageModelProgramExecutor {
     records: ChatMessage[],
     chatCompletionParams?: LanguageModelProgramExecutorExecuteOptions,
     functions?: FunctionSpecification[],
-    requestOptions?: RequestOptions,
-  ): Promise<ExecutorResponse<FunctionCallReturnType>>;
-
-  /**
-   * This an experimental interface that does not yet support functions and is optional to support
-   * for any custom executors.
-   *
-  */
-  experimentalStreamingExecute?<FunctionCallReturnType = undefined>(
-    messages: ChatMessage[],
-    completionParams?: LanguageModelProgramExecutorExecuteOptions,
+    requestOptions?: RequestOptionsNonStreaming,
+  ): Promise<NonStreamingExecuteResponse<FunctionCallReturnType>>;
+  
+  execute<FunctionCallReturnType = undefined>(
+    records: ChatMessage[],
+    chatCompletionParams?: LanguageModelProgramExecutorExecuteOptions,
     functions?: FunctionSpecification[],
-    requestOptions?: RequestOptions,
-  ): Promise<{
-    response: Promise<ExecutorResponse<FunctionCallReturnType>>,
-    stream: AsyncIterable<string>,
-  }>
+    requestOptions?: RequestOptionsStreaming,
+  ): Promise<StreamingExecuteResponse<FunctionCallReturnType>>;
 }
 
 /**

--- a/core/src/languageModels/reusableStream.ts
+++ b/core/src/languageModels/reusableStream.ts
@@ -1,0 +1,56 @@
+export class ReusableStream<T> {
+  private buffer: (T|null)[] = [];
+  private iterable: AsyncIterable<T>;
+  private resolvers:(() => void)[]
+  private firstPacketReceived = false
+  private onFirstHandler?: () => void
+
+  constructor(iterable: AsyncIterable<T>) {
+    this.iterable = iterable;
+    this.resolvers = []
+    this.go()
+  }
+
+  private async go() {
+    for await (const item of this.iterable) {
+      this.buffer.push(item);
+      this.resolveAll()
+      if (!this.firstPacketReceived && this.onFirstHandler) {
+        this.onFirstHandler()
+      }
+      this.firstPacketReceived = true
+    }
+    this.buffer.push(null);
+    this.resolveAll()
+  }
+
+  private resolveAll() {
+    this.resolvers.forEach(resolve => resolve())
+    this.resolvers = []
+  }
+
+  onFirst(handler: () => void) {
+    this.onFirstHandler = handler;
+    if (this.firstPacketReceived) {
+      handler()
+    }
+  }
+
+  async *stream() {
+    let i = 0
+    while (true) {
+      if (i < this.buffer.length) {
+        const val = this.buffer[i]
+        if (val === null) {
+          return
+        }
+        yield val
+        i++
+      } else {
+        await new Promise<void>((resolve) => {
+          this.resolvers.push(resolve)
+        })
+      }
+    }
+  }
+}

--- a/core/tests/cognitiveFunctions.spec.ts
+++ b/core/tests/cognitiveFunctions.spec.ts
@@ -4,9 +4,13 @@ import { CortexStep, externalDialog } from "../src";
 describe("cognitiveFunctions", () => {
   it("correctly strips boilerplate from LLM response when there's a verb", async () => {
     const step = new CortexStep("Samantha");
-    const result = externalDialog()();
+    const result = await externalDialog()();
 
-    const { value } = result.process(
+    if (!result.process) {
+      throw new Error("missing process")
+    }
+
+    const { value } = await result.process(
       step,
       `${step.entityName} said: "Meet me 6:00PM at the park"`
     );
@@ -15,9 +19,13 @@ describe("cognitiveFunctions", () => {
 
   it("correctly strips boilerplate from LLM response when there's NO verb", async () => {
     const step = new CortexStep("Samantha");
-    const result = externalDialog()();
+    const result = await externalDialog()();
+    
+    if (!result.process) {
+      throw new Error("missing process")
+    }
 
-    const { value } = result.process(
+    const { value } = await result.process(
       step,
       `${step.entityName}: "Meet me 6:00PM at the park"`
     );

--- a/core/tests/cortexStep.spec.ts
+++ b/core/tests/cortexStep.spec.ts
@@ -162,14 +162,14 @@ describe("CortexStep", () => {
     })
   })
 
-  it("EXPERIMENTALLY streams next steps", async () => {
+  it("streams next steps", async () => {
     const step = new CortexStep("BogusStreamer",)
     const { nextStep, stream } = await step.withMemory([
       {
         role: ChatMessageRoleEnum.System,
         content: "You are modeling the mind of Bogus, a very bad dude.",
       }
-    ]).experimentalStreamingNext(instruction("What one paragraph response would bogus have now?"))
+    ]).next(instruction("What one paragraph response would bogus have now?"), { stream: true})
 
     let streamed = ""
 

--- a/core/tests/languageModels/openAi.spec.ts
+++ b/core/tests/languageModels/openAi.spec.ts
@@ -7,7 +7,7 @@ describe("OpenAI Language Model", () => {
   it("streams responses", async () => {
     const processor = new OpenAILanguageProgramProcessor()
 
-    const { response: nextPromise, stream } = await processor.experimentalStreamingExecute(
+    const { response: nextPromise, stream } = await processor.execute(
       [
         {
         role: ChatMessageRoleEnum.System,
@@ -17,7 +17,10 @@ describe("OpenAI Language Model", () => {
           role: ChatMessageRoleEnum.User,
           content: "What paragagraph long response would bogus say now?"
         }
-      ]
+      ],
+      {},
+      [],
+      { stream: true }
     )
 
     let streamed = ""

--- a/docs/docs/CortexStep/intro.md
+++ b/docs/docs/CortexStep/intro.md
@@ -60,4 +60,4 @@ for await (const chunk of stream) {
 const resp = await nextStep
 ```
 
-Process functions from cogntivie functions (see below) run _after_ the stream is complete.
+Process functions from cognitive functions (see below) run _after_ the stream is complete.

--- a/docs/docs/CortexStep/intro.md
+++ b/docs/docs/CortexStep/intro.md
@@ -39,3 +39,25 @@ As this example illustrates, CortexStep operates on the principles of functional
 Compared to other tools like LangChain, which offer broader flexibility but also bring in complexity, CortexStep provides a more opinionated approach. It boasts a minimalistic API that ensures a clean abstraction layer over the language model, making the development process more straightforward.
 
 CortexStep excels at managing context, a crucial aspect when dealing with LLMs. It streamlines the creation of sophisticated behaviors with language models, making it easier to develop AI-powered conversations and tasks while avoiding common pitfalls.
+
+## Streaming
+
+Streaming is fully supported:
+
+```typescript
+const step = new CortexStep("EntityName");
+const { stream, nextStep } = await step.next(cognitiveFunction, { stream: true });
+
+let streamed = ""
+
+// stream is an AsyncIterable<string>
+for await (const chunk of stream) {
+  expect(chunk).to.be.a("string")
+  expect(chunk).to.exist
+  streamed += chunk
+}
+// nextStep is a Promise<CortexStep> that resolves when the stream is complete.
+const resp = await nextStep
+```
+
+Process functions from cogntivie functions (see below) run _after_ the stream is complete.


### PR DESCRIPTION
note: this merges into the #128  PR branch (will reset when that is merged)

This PR moves streaming into the standardized API, and moves it away from "experimental"

Also moves the interface to have a settable "stream" on next...

```
step.next(externalDialog('say hello'), { stream: true })
```
