### PR TITLE
stream manipulation

### DIFF
--- a/core/.eslintrc.cjs
+++ b/core/.eslintrc.cjs
@@ -4,4 +4,7 @@ module.exports = {
   parser: '@typescript-eslint/parser',
   plugins: ['@typescript-eslint'],
   root: true,
+  rules: {
+    "@typescript-eslint/no-explicit-any": "off"
+  },
 };

--- a/core/.eslintrc.json
+++ b/core/.eslintrc.json
@@ -14,5 +14,8 @@
   ],
   "plugins": [
     "@typescript-eslint"
-  ]
+  ],
+  "rules": {
+    "@typescript-eslint/no-explicit-any": "off"
+  }
 }

--- a/core/src/cognitiveFunctions.ts
+++ b/core/src/cognitiveFunctions.ts
@@ -12,14 +12,6 @@ const stripResponseBoilerPlate = ({ entityName }: CortexStep<any>, _verb: string
   return strippedResponse
 }
 
-/**
- * Processes an input stream by applying optional prefix and suffix filters.
- * If a prefix is defined, the stream will start after the prefix is matched.
- * If a suffix is defined, the stream will end when the suffix is matched.
- * @param stream - The input stream to be processed.
- * @param cognitiveFunc - The cognitive function containing the streamPrefix and streamSuffix.
- * @returns - Returns a Promise that resolves to an AsyncIterable<string> representing the processed stream.
- */
 const boilerPlateStreamProcessor = async ({ entityName }: CortexStep<any>, stream: AsyncIterable<string>): Promise<AsyncIterable<string>> => {
   const prefix = new RegExp(`^${entityName}.*?:\\s*["']*`, "i")
   const suffix = /["']$/

--- a/core/src/cognitiveFunctions.ts
+++ b/core/src/cognitiveFunctions.ts
@@ -6,9 +6,7 @@ import { html } from "common-tags";
 const stripResponseBoilerPlate = ({ entityName }: CortexStep<any>, _verb: string, response: string) => {
   // sometimes the LLM will respond with something like "Bogus said with a sinister smile: "I'm going to eat you!" (adding more words)
   // so we just strip any of those
-  let strippedResponse = response.replace(new RegExp(`${entityName} .*?:`, "i"), "").trim();
-  // sometimes the LLM will ignore the verb and just respond with: Bogus: "..."
-  strippedResponse = strippedResponse.replace(`${entityName}:`, "").trim();
+  let strippedResponse = response.replace(new RegExp(`${entityName}.*?:`, "i"), "").trim();
   // get rid of the quotes
   strippedResponse = strippedResponse.replace(/^["']|["']$/g, '').trim();
   return strippedResponse
@@ -39,6 +37,12 @@ export const externalDialog = (extraInstructions?: string, verb = "said") => {
 
           Please reply with the next utterance from ${name}. Use the format '${name} ${verb}: "..."'
         `;
+      },
+      stripStreamPrefix: ({ entityName }: CortexStep<any>) => {
+        return new RegExp(`^${entityName}.*?:\\s*["']*`, "i")
+      },
+      stripStreamSuffix: () => {
+        return /["']$/
       },
       commandRole: ChatMessageRoleEnum.System,
       process: (step: CortexStep<any>, response: string) => {
@@ -85,6 +89,12 @@ export const spokenDialog = (extraInstructions?: string, verb = "said") => {
           Please reply with the next utterance from ${name}. Use the format '${name} ${verb}: "..."'
         `;
       },
+      stripStreamPrefix: ({ entityName }: CortexStep<any>) => {
+        return new RegExp(`^${entityName}.*?:\\s*["']*`, "i")
+      },
+      stripStreamSuffix: () => {
+        return /["']$/
+      },
       commandRole: ChatMessageRoleEnum.System,
       process: (step: CortexStep<any>, response: string) => {
         return {
@@ -126,6 +136,12 @@ export const internalMonologue = (extraInstructions?: string, verb = "thought") 
 
           Please reply with the next internal monologue thought of ${name}. Use the format '${name} ${verb}: "..."'
       `},
+      stripStreamPrefix: ({ entityName }: CortexStep<any>) => {
+        return new RegExp(`^${entityName}.*?:\\s*["']*`, "i")
+      },
+      stripStreamSuffix: () => {
+        return /["']$/
+      },
       process: (step: CortexStep<any>, response: string) => {
         return {
           value: stripResponseBoilerPlate(step, verb, response),

--- a/core/src/cognitiveFunctions.ts
+++ b/core/src/cognitiveFunctions.ts
@@ -41,9 +41,7 @@ export const externalDialog = (extraInstructions?: string, verb = "said") => {
       stripStreamPrefix: ({ entityName }: CortexStep<any>) => {
         return new RegExp(`^${entityName}.*?:\\s*["']*`, "i")
       },
-      stripStreamSuffix: () => {
-        return /["']$/
-      },
+      stripStreamSuffix: /["']$/,
       commandRole: ChatMessageRoleEnum.System,
       process: (step: CortexStep<any>, response: string) => {
         const stripped = stripResponseBoilerPlate(step, verb, response)
@@ -92,9 +90,7 @@ export const spokenDialog = (extraInstructions?: string, verb = "said") => {
       stripStreamPrefix: ({ entityName }: CortexStep<any>) => {
         return new RegExp(`^${entityName}.*?:\\s*["']*`, "i")
       },
-      stripStreamSuffix: () => {
-        return /["']$/
-      },
+      stripStreamSuffix: /["']$/,
       commandRole: ChatMessageRoleEnum.System,
       process: (step: CortexStep<any>, response: string) => {
         return {
@@ -139,9 +135,7 @@ export const internalMonologue = (extraInstructions?: string, verb = "thought") 
       stripStreamPrefix: ({ entityName }: CortexStep<any>) => {
         return new RegExp(`^${entityName}.*?:\\s*["']*`, "i")
       },
-      stripStreamSuffix: () => {
-        return /["']$/
-      },
+      stripStreamSuffix: /["']$/,
       process: (step: CortexStep<any>, response: string) => {
         return {
           value: stripResponseBoilerPlate(step, verb, response),

--- a/core/src/cortexStep.ts
+++ b/core/src/cortexStep.ts
@@ -346,6 +346,10 @@ export class CortexStep<LastValueType = undefined> {
         }
       }
       buffer = [buffer, ...isStreamingBuffer].join('')
+      // if we ended before switching on streaming, then we haven't stripped the prefix yet.
+      if (!isStreaming && prefix) {
+        buffer = buffer.replace(prefix, '');
+      }
       if (buffer.length > 0) {
         // if there was some buffer left over, then we need to check if there was a suffix
         // and remove that from the last part of the stream.

--- a/core/tests/cortexStep.spec.ts
+++ b/core/tests/cortexStep.spec.ts
@@ -199,7 +199,7 @@ describe("CortexStep", () => {
         role: ChatMessageRoleEnum.System,
         content: "You are modeling the mind of Bogus, a very bad dude.",
       }
-    ]).next(instruction("What one paragraph response would bogus have now?"), { stream: true})
+    ]).next(externalDialog("Bogus says a Haiku."), { stream: true})
 
     let streamed = ""
 
@@ -211,7 +211,6 @@ describe("CortexStep", () => {
       expect(chunk).to.exist
       streamed += chunk
     }
-    expect(resp.memories[resp.memories.length - 1].content).to.eq(resp.value)
     expect(resp.value).to.be.an("string")
     expect(resp.value).to.eq(streamed)
     expect(resp.value).to.have.length.greaterThan(10)


### PR DESCRIPTION
This lets you strip a prefix and a suffix off a stream as it's coming in.

By necessity, you need to buffer some of the stream in order to do this, right now I keep two chunks buffered until the stream ends.

This lets you specify the prefix/suffix as either plain strings or regexes or functions that return regexes or strings (this lets you do things like use the entityName in the regexes).

The test in cortexstep checks to make sure the value matches the stream (it otherwise wouldn't without the prefix/suffix on externalDialog)