### PR TITLE
mentalQuery cognitive function

### DIFF
--- a/core/src/cognitiveFunctions.ts
+++ b/core/src/cognitiveFunctions.ts
@@ -294,6 +294,13 @@ export const queryMemory = (query: string) => {
   return questionMemory(query)
 }
 
+/**
+ * questionMemory is used to retrieve a detailed answer from memory based on a given question.
+ * Unlike mentalQuery, which is designed to determine the truth value (true/false) of a statement,
+ * questionMemory aims to provide a comprehensive response.
+ *
+ * @param question - The question to answer from memory
+ */
 export const questionMemory = (question: string) => {
   return () => {
     const params = z.object({

--- a/core/src/cognitiveFunctions.ts
+++ b/core/src/cognitiveFunctions.ts
@@ -337,7 +337,6 @@ export const questionMemory = (question: string) => {
   }
 }
 
-
 // This is an internal use function that is used in mentalQuery to make the decision *after* thinking through the answer.
 const _mentalQueryDecision = (statement: string) => {
   return ({entityName: name}: CortexStep<any>) => {
@@ -418,7 +417,7 @@ export const instruction = (command: StepCommand): NextFunction<string, string> 
 }
 
 /**
- * @deprecated
+ * @deprecated will be removed in 0.2.0, use instruction instead.
  */
 export const stringCommand = (command: StepCommand) => {
   return instruction(command)

--- a/core/src/cognitiveFunctions.ts
+++ b/core/src/cognitiveFunctions.ts
@@ -1,5 +1,5 @@
 import { EnumLike, z } from "zod"
-import { CortexStep, NextFunction, StepCommand } from "./cortexStep";
+import { BrainFunction, CortexStep, NextFunction, StepCommand } from "./cortexStep";
 import { ChatMessageRoleEnum } from "./languageModels";
 import { html } from "common-tags";
 
@@ -15,7 +15,7 @@ const stripResponseBoilerPlate = ({ entityName }: CortexStep<any>, _verb: string
 const boilerPlateStreamProcessor = async ({ entityName }: CortexStep<any>, stream: AsyncIterable<string>): Promise<AsyncIterable<string>> => {
   const prefix = new RegExp(`^${entityName}.*?:\\s*["']*`, "i")
   const suffix = /["']$/
-  
+
   let isStreaming = !prefix
   let prefixMatched = !prefix
   let buffer = ""
@@ -286,22 +286,33 @@ export const brainstorm = (description: string) => {
   }
 }
 
+
+/**
+ * @deprecated since version 0.1.3, will be removed in version 0.2.0. Use questionMemory instead.
+ */
 export const queryMemory = (query: string) => {
+  return questionMemory(query)
+}
+
+export const questionMemory = (question: string) => {
   return () => {
     const params = z.object({
-      answer: z.string().describe(`The answer to: ${query}`)
+      answer: z.string().describe(`The answer to: ${question}`)
     });
 
     return {
       name: "query_memory",
-      description: query,
+      description: question,
       parameters: params,
       command: html`
-        Do not repeat ${query} and instead use the dialog history.
-        Do not copy sections of the chat history as an answer.
-        Do summarize and thoughtfully answer in sentence and paragraph format.
-        
-        Take a deep breath, analyze the chat history step by step and answer the question: ${query}.
+        ## Instructions
+        * Do not repeat the question in your answer.
+        * Do not copy sections of the chat history as an answer.
+        * Do summarize and thoughtfully answer in sentence and paragraph format.
+        * Do use the dialog history to answer the question.
+
+        Take a deep breath, analyze the chat history step by step and answer the question:
+        > ${question}.
       `,
       process: (_step: CortexStep<any>, response: z.infer<typeof params>) => {
         // Use the inferred type from the Zod schema
@@ -310,12 +321,79 @@ export const queryMemory = (query: string) => {
           memories: [{
             role: ChatMessageRoleEnum.Assistant,
             content: html`
-              The answer to ${query} is ${response.answer}.
+              The answer to ${question} is ${response.answer}.
             `
           }],
         }
       }
     };
+  }
+}
+
+
+// This is an internal use function that is used in mentalQuery to make the decision *after* thinking through the answer.
+const _mentalQueryDecision = (statement: string) => {
+  return ({entityName: name}: CortexStep<any>) => {
+
+    const params = z.object({
+      decision: z.boolean().describe(`Is the statement true or false in the mind of ${name}?`)
+    })
+
+    return {
+      description: html`
+        Save whether or not ${name} believes the following statement to be true or false:
+        > ${statement}
+      `,
+      name: "mentalQuery",
+      parameters: params
+    };
+  }
+}
+
+/**
+ * mentalQuery is used to model the mind of an entity and make a decision based on a question. The `question` parameter should be a true or false statement.
+ * 
+ * Example:
+ * mentalQuery("The meeting is today.")
+ * 
+ * @param statement - A true or false statement that the entity evaluates.
+ * 
+ * When used in a CortexStep#next or #compute command, the typed #value will be the boolean result of the decision process, reflecting the entity's belief.
+ * This cognitive function makes two calls to the underlying LanguageProcessor: one to think through 
+ */
+export const mentalQuery = (statement: string) => {
+  // *first* we create an internal thought that we'll use to guide the decision making process.
+  return () => {
+
+    return {
+      command: ({ entityName: name }: CortexStep) => {
+        return html`
+          ${name} decides if the following statement is true or false and gives their reasoning:
+          > ${statement}
+
+          Please reply with whether or not ${name} thinks the statement is true or false and provide their reasoning. Use the format '${name} decided: "..."'
+      `},
+      process: async (step: CortexStep<any>, response: string) => {
+        const stepWithThought = step.withMemory([{
+          role: ChatMessageRoleEnum.Assistant,
+          content: html`
+            ${step.entityName} considered if the following statment is true or false:
+            > ${statement}
+            ${response}
+          `
+        }])
+
+        const { decision } = await stepWithThought.compute(_mentalQueryDecision(statement))
+        
+        return {
+          value: decision,
+          memories: [{
+            content: `${step.entityName} evaluated: \`${statement}\` and decided that the statement is ${decision}`,
+            role: ChatMessageRoleEnum.Assistant
+          }],
+        }
+      }
+    }
   }
 }
 

--- a/core/src/cognitiveFunctions.ts
+++ b/core/src/cognitiveFunctions.ts
@@ -1,5 +1,5 @@
 import { EnumLike, z } from "zod"
-import { BrainFunction, CortexStep, NextFunction, StepCommand } from "./cortexStep";
+import { CortexStep, NextFunction, StepCommand } from "./cortexStep";
 import { ChatMessageRoleEnum } from "./languageModels";
 import { html } from "common-tags";
 

--- a/core/tests/cognitiveFunctions.spec.ts
+++ b/core/tests/cognitiveFunctions.spec.ts
@@ -79,7 +79,6 @@ describe("cognitiveFunctions", () => {
       ])
 
       const result = await game.next(mentalQuery(`Samantha's conversation partner told them they guessed the rockstar correctly.`))
-      // const result = await game.next(mentalQuery(`Samantha has guessed the rockstar correctly.`))
       expect(result.value).to.be.false
     })
   })

--- a/core/tests/cognitiveFunctions.spec.ts
+++ b/core/tests/cognitiveFunctions.spec.ts
@@ -1,5 +1,7 @@
 import { expect } from "chai";
-import { CortexStep, externalDialog } from "../src";
+import { ChatMessageRoleEnum, CortexStep, externalDialog, mentalQuery } from "../src";
+import { html } from "common-tags";
+import { beforeEach } from "mocha";
 
 describe("cognitiveFunctions", () => {
   it("correctly strips boilerplate from LLM response when there's a verb", async () => {
@@ -31,4 +33,54 @@ describe("cognitiveFunctions", () => {
     );
     expect(value).to.be.equal("Meet me 6:00PM at the park");
   });
+
+  describe.only("mentalQuery", () => {
+    let samantha: CortexStep
+    beforeEach(async () => {
+      samantha = new CortexStep("Samantha").withMemory([{
+        role: ChatMessageRoleEnum.System,
+        content: html`
+          You are modeling the mind of Samantha, a gen-z quantum computer physicist.
+        `
+      }])
+    })
+
+    it("decides true on a simple statement", async () => {
+      const result = await samantha.next(mentalQuery(`The sky is blue`))
+      expect(result.value).to.be.true
+    })
+
+    it("decides false on a simple statement", async () => {
+      const result = await samantha.next(mentalQuery(`Samantha is a professional gardener.`))
+      expect(result.value).to.be.false
+    })
+
+    it("decides true on a more complex dialog interaction", async () => {
+      const game = samantha.withMemory([
+        {
+          role: ChatMessageRoleEnum.System,
+          content: html`
+            ## Conversational Setting
+            Samantha is playing a guessing game where the user thinks of a rock star and Samantha tries to guess who the rock star is by asking yes or no questions.
+          `
+        },
+        {
+          role: ChatMessageRoleEnum.Assistant,
+          content: html`
+            Samantha said: Did the artist die before 1980?
+          `
+        },
+        {
+          role: ChatMessageRoleEnum.User,
+          content: html`
+            Interlocutor said: YES! THEY SURE DID!
+          `
+        },
+      ])
+
+      const result = await game.next(mentalQuery(`Samantha's conversation partner told them they guessed the rockstar correctly.`))
+      // const result = await game.next(mentalQuery(`Samantha has guessed the rockstar correctly.`))
+      expect(result.value).to.be.false
+    })
+  })
 });

--- a/core/tests/cognitiveFunctions.spec.ts
+++ b/core/tests/cognitiveFunctions.spec.ts
@@ -34,7 +34,7 @@ describe("cognitiveFunctions", () => {
     expect(value).to.be.equal("Meet me 6:00PM at the park");
   });
 
-  describe.only("mentalQuery", () => {
+  describe("mentalQuery", () => {
     let samantha: CortexStep
     beforeEach(async () => {
       samantha = new CortexStep("Samantha").withMemory([{

--- a/core/tests/cortexStep.spec.ts
+++ b/core/tests/cortexStep.spec.ts
@@ -1,4 +1,4 @@
-import { ChatMessageRoleEnum, CortexStep, decision, instruction, queryMemory, externalDialog, internalMonologue, spokenDialog } from "../src";
+import { ChatMessageRoleEnum, CortexStep, decision, instruction, questionMemory, externalDialog, internalMonologue, spokenDialog } from "../src";
 import { expect } from "chai";
 import { z } from "zod";
 import { trace } from "@opentelemetry/api";
@@ -352,13 +352,13 @@ describe("CortexStep", () => {
           const exclaims = await shouts.next(externalDialog("Bogus exclaims!"))
           const continues = await exclaims.next(externalDialog("Bogus continues"))
           console.log(continues.toString());
-          const query = (await continues.next(queryMemory("Please provide a summary of everything Bogus said"))).value
+          const query = (await continues.next(questionMemory("Please provide a summary of everything Bogus said"))).value
           span.end()
           console.log(query)
           expect(query).to.have.length.greaterThan(10)
         } else {
           console.log(action.toString())
-          const query = (await action.next(queryMemory("Please provide a summary of everything Bogus said"))).value
+          const query = (await action.next(questionMemory("Please provide a summary of everything Bogus said"))).value
           span.end()
           console.log(query)
           expect(query).to.have.length.greaterThan(10)

--- a/core/tests/languageModels/functionlessLLM.spec.ts
+++ b/core/tests/languageModels/functionlessLLM.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { CortexStep, ChatMessageRoleEnum, decision, externalDialog, internalMonologue, queryMemory, z } from "../../src";
+import { CortexStep, ChatMessageRoleEnum, decision, externalDialog, internalMonologue, questionMemory, z } from "../../src";
 import { FunctionlessLLM } from "../../src/languageModels/FunctionlessLLM";
 
 // this is set to skip because it requires a locally running LLM server.
@@ -93,12 +93,12 @@ describe.skip("FunctionlessLLM", () => {
         const exclaims = await shouts.next(externalDialog("Bogus exclaims!"))
         const continues = await exclaims.next(externalDialog("Bogus continues"))
         console.log(continues.toString());
-        const query = (await continues.next(queryMemory("Please provide a summary of everything Bogus said"))).value
+        const query = (await continues.next(questionMemory("Please provide a summary of everything Bogus said"))).value
         console.log(query)
         expect(query).to.have.length.greaterThan(10)
       } else {
         console.log(action.toString())
-        const query = (await action.next(queryMemory("Please provide a summary of everything Bogus said"))).value
+        const query = (await action.next(questionMemory("Please provide a summary of everything Bogus said"))).value
         console.log(query)
         expect(query).to.have.length.greaterThan(10)
       }


### PR DESCRIPTION
mentalQuery is used to determine if an entity thinks a statement is true or false. It's very useful for flow control in a mental subroutine.

For instance:

`Samantha believes the user is lying`
or
`The user has answered the question correctly`

mentalQuery makes two calls to the underlying LanguageProcessor:
First, the entity thinks through their answer to the veracity of that statement and provides their reasoning.
Next, we extract the actual answer from their reasoning.