### PR TITLE
add the ability to switch the model on an individual next call

### DIFF
--- a/core/src/cortexStep.ts
+++ b/core/src/cortexStep.ts
@@ -10,6 +10,8 @@ const tracer = trace.getTracer(
 );
 
 export interface NextOptions {
+  // allows specifying an alternative model
+  model?: string
   requestOptions?: RequestOptions
   tags?: Record<string, string>
   stream?: boolean
@@ -202,6 +204,7 @@ export class CortexStep<LastValueType = undefined> {
       const resp = await this.processor.execute<ParsedArgumentType>(
         memories,
         {
+          ...(opts.model ? { model: opts.model } : {}),
           functionCall: rawFn.specification.name ? { name: rawFn.specification.name } : undefined,
         },
         (rawFn.specification.name ? [rawFn.specification as FunctionSpecification] : []),
@@ -250,6 +253,7 @@ export class CortexStep<LastValueType = undefined> {
       const { response, stream: rawStream } = await this.processor.execute<ParsedArgumentType>(
         memories,
         {
+          ...(opts.model ? { model: opts.model } : {}),
           functionCall: rawFn.specification.name ? { name: rawFn.specification.name } : undefined,
         },
         (rawFn.specification.name ? [rawFn.specification as FunctionSpecification] : []),

--- a/core/src/languageModels/index.ts
+++ b/core/src/languageModels/index.ts
@@ -6,6 +6,7 @@ export { FunctionlessLLM } from "./FunctionlessLLM";
 export interface LanguageModelProgramExecutorExecuteOptions {
   stop?: string;
   functionCall?: "none" | "auto" | { name: string };
+  model?: string;
 }
 
 export interface ExecutorResponse<FunctionCallArgumentsType = any> {
@@ -19,7 +20,8 @@ export type Headers = Record<string, string | null | undefined>;
 export interface RequestOptions {
   signal?: AbortSignal | null;
   headers?: Headers;
-  stream?: boolean
+  stream?: boolean;
+  timeout?: number;
 }
   
 export interface RequestOptionsStreaming extends RequestOptions {

--- a/core/src/languageModels/openAI.ts
+++ b/core/src/languageModels/openAI.ts
@@ -88,7 +88,9 @@ export class OpenAILanguageProgramProcessor
       ...defaultCompletionParams,
       stream: false,
     };
-    this.defaultRequestOptions = defaultRequestOptions || {}
+    this.defaultRequestOptions = {
+      ...defaultRequestOptions
+    }
   }
 
   private validateFunctioncall(requestedFunction: LanguageModelProgramExecutorExecuteOptions["functionCall"], message: ChatCompletionMessage | undefined, functions: FunctionSpecification[]): ValidateFunctionCallResult {
@@ -320,11 +322,11 @@ export class OpenAILanguageProgramProcessor
 
     return tracer.startActiveSpan('execute', async (span) => {
       try {
-        const { functionCall, ...restRequestParams } = completionParams;
+        const { functionCall, ...completionParamsWithoutFunctionCall } = completionParams;
 
         const params = {
           ...this.defaultCompletionParams,
-          ...restRequestParams,
+          ...completionParamsWithoutFunctionCall,
           function_call: functionCall,
           messages: messages as ChatCompletionMessageParam[],
         }

--- a/core/tests/cortexStep.spec.ts
+++ b/core/tests/cortexStep.spec.ts
@@ -315,6 +315,16 @@ describe("CortexStep", () => {
     expect(val).to.equal("yes")
   })
 
+  it("handles switching the model on an individual next call", async () => {
+    const step = new CortexStep("Samantha").withMemory([{
+      role: ChatMessageRoleEnum.System,
+      content: "You are modeling the mind of Samantha, a quantum physicist.",
+    }])
+
+    const resp = await step.next(externalDialog("What does Bogus say?"), { model: "gpt-3.5-turbo-1106" })
+    expect(resp.value).to.be.a("string")
+  })
+
   it('does a long bogus monologue', async () => {
     return tracer.startActiveSpan('bogus-monologue', async (span) => {
       try {


### PR DESCRIPTION
this PR lets you keep your language processor, but switch models out on a per .next or .compute call:

```typescript
    const resp = await step.next(externalDialog("What does Bogus say?"), { model: "gpt-3.5-turbo-1106" })
```

