### PR TITLE
woops, no messages were system messages

### DIFF
--- a/core/src/languageModels/FunctionlessLLM.ts
+++ b/core/src/languageModels/FunctionlessLLM.ts
@@ -215,12 +215,12 @@ export class FunctionlessLLM implements LanguageModelProgramExecutor {
     if (!this.singleSystemMessage) {
       return messages as ChatCompletionMessageParam[]
     }
-    let firstSystemMessage = false
+    let firstSystemMessage = true
     return messages.map((originalMessage) => {
       const message = { ...originalMessage }
       if (message.role === ChatMessageRoleEnum.System) {
         if (firstSystemMessage) {
-          firstSystemMessage = true
+          firstSystemMessage = false
           return message
         }
         message.role = ChatMessageRoleEnum.User


### PR DESCRIPTION
oops #142 introduced a small bug, where *all* the system messages were being overwritten.