### PR TITLE
minor doc updates

### DIFF
--- a/docs/docs/CortexStep/advancedExamples.md
+++ b/docs/docs/CortexStep/advancedExamples.md
@@ -1,13 +1,9 @@
 ---
-id: advanced-examples
+id: metacognition
 sidebar_position: 7
 ---
 
-# Advanced Examples
-
-This collection of advanced examples illustrates quite complex topics at the frontier of AI cognitive modeling.
-
-## Metacognition
+# Metacognition
 
 Here we display a much more complex example of the following and intriguing concept: what if an AI Soul is given the capacity to remember and think about how it is thinking? This concept is generally known as metacognition, and is a core skill humans display. This example is currently presented without further context.
 

--- a/docs/docs/CortexStep/api.md
+++ b/docs/docs/CortexStep/api.md
@@ -96,7 +96,7 @@ let lastValue = step.value;
 Response streaming is fully support on `.next` steps
 
 ```javascript
-const { stream, nextStep } = await step.next(internalMonologue("thinks, understanding the user's message"), { stream: "true" });
+const { stream, nextStep } = await step.next(internalMonologue("thinks, understanding the user's message"), { stream: true });
 for await (const chunk of stream) {
    console.log(chunk);
 }

--- a/docs/docs/CortexStep/api.md
+++ b/docs/docs/CortexStep/api.md
@@ -90,3 +90,21 @@ While `CortexStep` allows for the creation of [custom cognitive functions](actio
 ```javascript
 let lastValue = step.value;
 ```
+
+## Streaming support
+
+Response streaming is fully support on `.next` steps
+
+```javascript
+const { stream, nextStep } = await step.next(internalMonologue("thinks, understanding the user's message"), { stream: "true" });
+for await (const chunk of stream) {
+   console.log(chunk);
+}
+step = await nextStep;
+```
+
+## Model specification
+
+By default, `CortexStep` is configured to use OpenAI models. On each `.next` step or `.compute` call, an OpenAI model string can optionally be passed as `.next(..., { model: "gpt-3.5-turbo-1106" })`.
+
+We also have first-class support for open source models through optional specification of a [language model executor interface](/languageModels) when constructing a `CortexStep`.

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -32,4 +32,4 @@ We recently updated our codebase to a new version of socialagi. Older code is pr
 
 ## Supported LLMs
 
-SocialAGI is primarily intended to work with OpenAI, however, it is possible to substitute in any language model through our [executor and streaming interfaces](/languageModels).
+SocialAGI is primarily intended to work with OpenAI, however, it is possible to substitute in any language model through our [language model executor interface](/languageModels).

--- a/docs/docs/languageModels.md
+++ b/docs/docs/languageModels.md
@@ -36,12 +36,38 @@ interface LanguageModelProgramExecutor {
 We also include a `FunctionlessLLM` `LanguageModelProgramExecutor` implementation that supports APIs with OpenAI chat API support (but does *not* require function calling support). This executor also supports calling APIs that do not allow more than one system message:
 
 ```typescript
-  let step = new CortexStep("Jonathan", {
-    processor: new FunctionlessLLM({
-      baseURL: "http://localhost:1234/v1",
-      compressSystemMessages: true,
-    })
-  });
+let step = new CortexStep("Jonathan", {
+  processor: new FunctionlessLLM({
+    baseURL: "http://localhost:1234/v1",
+    compressSystemMessages: true,
+  })
+});
+```
+
+Many Mistral and Together AI models work with this same interface, though we recommend only using their most intelligent models, e.g.
+```typescript
+const monologue = new CortexStep("Jonathan", {
+  processor: new FunctionlessLLM({
+  baseURL: "https://api.mistral.ai/v1/",
+  singleSystemMessage: true,
+  apiKey: "your_xyz_MISTRAL_API_KEY",
+}, {
+  model: "mistral-medium",
+  temperature: 0.8,
+  max_tokens: 300,
+})
+```
+or
+```typescript
+processor: new FunctionlessLLM({
+  baseURL: "https://api.together.xyz/v1",
+  singleSystemMessage: true,
+  apiKey: "your_xyz_TOGETHER_API_KEY",
+}, {
+  model: "NousResearch/Nous-Hermes-2-Yi-34B",
+  temperature: 0.7,
+  max_tokens: 300,
+})
 ```
 
 ### Example OpenAI completion engines

--- a/docs/docs/languageModels.md
+++ b/docs/docs/languageModels.md
@@ -46,27 +46,30 @@ let step = new CortexStep("Jonathan", {
 
 Many Mistral and Together AI models work with this same interface, though we recommend only using their most intelligent models, e.g.
 ```typescript
-const monologue = new CortexStep("Jonathan", {
-  processor: new FunctionlessLLM({
-  baseURL: "https://api.mistral.ai/v1/",
-  singleSystemMessage: true,
-  apiKey: "your_xyz_MISTRAL_API_KEY",
-}, {
-  model: "mistral-medium",
-  temperature: 0.8,
-  max_tokens: 300,
+let step = new CortexStep("Jonathan", {
+    processor: new FunctionlessLLM({
+    baseURL: "https://api.mistral.ai/v1/",
+    singleSystemMessage: true,
+    apiKey: "your_xyz_MISTRAL_API_KEY",
+  }, {
+    model: "mistral-medium",
+    temperature: 0.8,
+    max_tokens: 300,
+  })
 })
 ```
 or
 ```typescript
-processor: new FunctionlessLLM({
-  baseURL: "https://api.together.xyz/v1",
-  singleSystemMessage: true,
-  apiKey: "your_xyz_TOGETHER_API_KEY",
-}, {
-  model: "NousResearch/Nous-Hermes-2-Yi-34B",
-  temperature: 0.7,
-  max_tokens: 300,
+let step = new CortexStep("Jonathan", {
+  processor: new FunctionlessLLM({
+    baseURL: "https://api.together.xyz/v1",
+    singleSystemMessage: true,
+    apiKey: "your_xyz_TOGETHER_API_KEY",
+  }, {
+    model: "NousResearch/Nous-Hermes-2-Yi-34B",
+    temperature: 0.7,
+    max_tokens: 300,
+  })
 })
 ```
 

--- a/docs/docs/languageModels.md
+++ b/docs/docs/languageModels.md
@@ -56,32 +56,3 @@ const executor = new OpenAILanguageProgramProcessor(
   },
 );
 ```
-
-## Next.js edge functions
-
-SocialAGI supports cognitive processing in the frontend through Next.js edge function support. In this paradigm, the executor and/or streamers are implemented via calls to Next.js edge functions. This requires a few pieces to setup:
-
-`api/lmExecutor` endpoint, configured with
-
-```javascript
-module.exports = createOpenAIExecutorHandler(Model.GPT_3_5_turbo_16k);
-```
-
-and/or
-
-`api/lmStreamer` endpoint, configured with
-
-```javascript
-module.exports = createOpenAIStreamHandler(Model.GPT_3_5_turbo_16k);
-```
-
-Then, the executor and streamer respectively are instantiated in the frontend via:
-
-```javascript
-const streamer = createChatCompletionStreamer("/api/lmStreamer");
-const executor = createChatCompletionExecutor("/api/lmExecutor");
-```
-
-A complete running example using this paradigm can be found in this [example SocialAGI web project](https://github.com/opensouls/socialagi-ex-webapp/tree/ede679932649b8f1f6704ac70218826d03b69af7).
-
-Similar paradigms could be extended to other frontend/web request frameworks than Next.js edge functions.


### PR DESCRIPTION
reflect some of the recent changes

- new LM executor class
- nextjs integration type stuff is no longer supported directly in socialagi
- reflext .next step options
- call out together & mistral

this isn't exactly reflected here but i think we've essentially downscoped socialagi to be about the minutia of modeling cognitive process flow

so like this on the main readme

```
SocialAGI aims to simplify the developer experience as much as possible in creating agentic and embodied chatbots called AI Souls, comprising thousands of linguistic instructions (managed by SocialAGI). Unlike traditional chatbots, these SocialAGI instructions will give digital souls personality, drive, ego, and will.

We are solving problems all the way across the AI souls stack, including:

How do I create the most lifelike AI entity?
How do I quickly host an AI soul?
How do I manage dialog and cognitive memory?
How do I get away from boring technical details and instead sculpt personalities?
```

needs to be downscoped since the soul engine is doing a lot of this